### PR TITLE
Add event queue support

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -663,8 +663,10 @@ Queue Management Commands
 monitor_event_queue
 ~~~~~~~~~~~~~~~~~~
 
-Monitor the event queue and display or save events as they arrive. This command continuously
-monitors the event queue for new messages and can optionally save them to a file.
+Monitor the event queue and display and save events as they arrive. For safety, saving to a
+file is not optional and the `--output-file` option is required. New events will be appended
+to this file so be careful to delete any previous file if you want the list of events to start
+fresh.
 
 .. code-block:: none
 
@@ -675,7 +677,7 @@ monitors the event queue for new messages and can optionally save them to a file
 
 Additional options:
 
---output-file FILE    File to write events to (will be opened in append mode)
+--output-file FILE    File to write events to (will be opened in append mode) [required]
 
 Examples:
 
@@ -828,7 +830,7 @@ Examples:
 purge_queue
 ~~~~~~~~~~~
 
-Remove all messages from the task and results queues. This allows you to start fresh by loading
+Remove all messages from the task and event queues. This allows you to start fresh by loading
 new tasks.
 
 .. code-block:: none
@@ -841,8 +843,8 @@ new tasks.
 
 Additional options:
 
---task-queue-only      Purge only the task queue (not the results queue)
---results-queue-only   Purge only the results queue (not the task queue)
+--task-queue-only      Purge only the task queue (not the event queue)
+--event-queue-only     Purge only the event queue (not the task queue)
 --force                Purge without confirmation
 
 Examples:
@@ -878,7 +880,7 @@ Examples:
 delete_queue
 ~~~~~~~~~~~~
 
-Delete the task and results queues and their infrastructure. This permanently frees up the
+Delete the task and event queues and their infrastructure. This permanently frees up the
 resources used by the queues. Only do this if there are no processes running that use the
 queues.
 
@@ -892,8 +894,8 @@ queues.
 
 Additional options:
 
---task-queue-only      Purge only the task queue (not the results queue)
---results-queue-only   Purge only the results queue (not the task queue)
+--task-queue-only      Delete only the task queue (not the event queue)
+--event-queue-only     Delete only the event queue (not the task queue)
 --force                Delete without confirmation
 
 Examples:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -781,8 +781,8 @@ Examples:
 purge_queue
 ~~~~~~~~~~~
 
-Remove all messages from a queue. This can be used to delete any remaining tasks; you can
-then reload the queue with new tasks if needed.
+Remove all messages from the task and results queues. This allows you to start fresh by loading
+new tasks.
 
 .. code-block:: none
 
@@ -794,7 +794,9 @@ then reload the queue with new tasks if needed.
 
 Additional options:
 
---force           Purge without confirmation
+--task-queue-only      Purge only the task queue (not the results queue)
+--results-queue-only   Purge only the results queue (not the task queue)
+--force                Purge without confirmation
 
 Examples:
 
@@ -828,8 +830,9 @@ Examples:
 delete_queue
 ~~~~~~~~~~~~
 
-Delete a queue and its infrastructure. This permanently frees up the resources used by the
-queue. Only do this if there are no processes running that use the queue.
+Delete the task and results queues and their infrastructure. This permanently frees up the
+resources used by the queues. Only do this if there are no processes running that use the
+queues.
 
 .. code-block:: none
 
@@ -841,7 +844,9 @@ queue. Only do this if there are no processes running that use the queue.
 
 Additional options:
 
---force           Delete without confirmation
+--task-queue-only      Purge only the task queue (not the results queue)
+--results-queue-only   Purge only the results queue (not the task queue)
+--force                Delete without confirmation
 
 Examples:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -502,7 +502,7 @@ command.
 
 Additional options:
 
---tasks TASKS_FILE                    Path to tasks file (JSON or YAML)
+--task-file TASK_FILE                 Path to tasks file (JSON or YAML)
 --start-task N                        Skip tasks until this task number (1-based)
 --limit N                             Maximum number of tasks to enqueue
 --max-concurrent-queue-operations N   Maximum concurrent tasks to enqueue (default: 100)
@@ -721,7 +721,7 @@ of the queue.
 
 Additional options:
 
---tasks TASKS_FILE                    Path to tasks file (JSON or YAML)
+--task-file TASK_FILE                 Path to tasks file (JSON or YAML)
 --start-task N                        Skip tasks until this task number (1-based)
 --limit N                             Maximum number of tasks to enqueue
 --max-concurrent-queue-operations N   Maximum concurrent queue operations (default: 100)
@@ -734,7 +734,7 @@ Examples:
 
       .. code-block:: none
 
-         $ cloud_tasks load_queue --provider aws --job-id my-job --tasks examples/parallel_addition/addition_tasks.json
+         $ cloud_tasks load_queue --provider aws --job-id my-job --task-file examples/parallel_addition/addition_tasks.json
          Creating task queue 'my-job' on AWS if necessary...
          Populating task queue from examples/parallel_addition/addition_tasks.json...
          Enqueueing tasks: 10000it [00:13, 735.74it/s]
@@ -745,7 +745,7 @@ Examples:
 
       .. code-block:: none
 
-         $ cloud_tasks load_queue --provider gcp --job-id my-job --project my-project --tasks examples/parallel_addition/addition_tasks.json
+         $ cloud_tasks load_queue --provider gcp --job-id my-job --project my-project --task-file examples/parallel_addition/addition_tasks.json
          Creating task queue 'my-job' on GCP if necessary...
          Populating task queue from examples/parallel_addition/addition_tasks.json...
          Enqueueing tasks: 10000it [00:07, 1414.18it/s]

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -415,58 +415,6 @@ Examples:
          n2-highmem-96                X86_64   96      768.0          0          0     $6.2887  us-central1-*
 
 
-.. _cli_list_running_instances:
-
-list_running_instances
-~~~~~~~~~~~~~~~~~~~~~~
-
-List currently running instances. By default only active instances created by Cloud Tasks
-are shown. If only a region is specified, instances in all zones in that region are shown. If a
-zone is specified, only instances in that zone are shown.
-
-.. code-block:: none
-
-   cloud_tasks list_running_instances
-     [Common options]
-     [Provider-specific options]
-     [Additional options]
-
-Additional options:
-
---job-id JOB_ID         Filter by job ID
---all-instances         Show all instances including ones that were not created by Cloud Tasks
---include-terminated    Include terminated instances
---sort-by FIELDS        Sort results by comma-separated fields (e.g.,
-                        "state,type" or "-created,id"). Available fields: id, type, state,
-                        zone, creation_time. Prefix with "-" for descending order. Partial
-                        field names like "t" for "type" or "s" for "state" are supported.
---detail                Show detailed information
-
-Examples:
-
-.. tabs::
-
-   .. tab:: AWS
-
-      TODO
-
-   .. tab:: GCP
-
-      .. code-block:: none
-
-         $ cloud_tasks list_running_instances --provider gcp --project my-project --region us-central1 --all-instances --include-terminated
-         Listing all instances including ones not created by cloud tasks
-
-         Job ID           ID                                                               Type            State       Zone            Created
-         -----------------------------------------------------------------------------------------------------------------------------------------------------------
-         N/A              personal-instance-1                                              e2-micro        running     us-central1-c   2025-04-28T14:33:46.974-07:00
-         my-job           rmscr-my-job-b2siduvm6a88og25yu5z76kkd                           e2-micro        terminated  us-central1-b   2025-04-28T14:22:01.786-07:00
-         my-job           rmscr-my-job-cjh38y7dttesfqkdbx4ew6kxb                           e2-micro        running     us-central1-a   2025-04-28T14:22:01.585-07:00
-
-         Summary: 3 total instances
-         2 running
-         1 terminated
-
 .. _cli_job_management_commands:
 
 Job Management Commands
@@ -651,8 +599,107 @@ Examples:
          Job 'my-job' stopped
 
 
+.. _cli_list_running_instances:
+
+list_running_instances
+~~~~~~~~~~~~~~~~~~~~~~
+
+List currently running instances. By default only active instances created by Cloud Tasks
+are shown. If only a region is specified, instances in all zones in that region are shown. If a
+zone is specified, only instances in that zone are shown.
+
+.. code-block:: none
+
+   cloud_tasks list_running_instances
+     [Common options]
+     [Provider-specific options]
+     [Additional options]
+
+Additional options:
+
+--job-id JOB_ID         Filter by job ID
+--all-instances         Show all instances including ones that were not created by Cloud Tasks
+--include-terminated    Include terminated instances
+--sort-by FIELDS        Sort results by comma-separated fields (e.g.,
+                        "state,type" or "-created,id"). Available fields: id, type, state,
+                        zone, creation_time. Prefix with "-" for descending order. Partial
+                        field names like "t" for "type" or "s" for "state" are supported.
+--detail                Show detailed information
+
+Examples:
+
+.. tabs::
+
+   .. tab:: AWS
+
+      TODO
+
+   .. tab:: GCP
+
+      .. code-block:: none
+
+         $ cloud_tasks list_running_instances --provider gcp --project my-project --region us-central1 --all-instances --include-terminated
+         Listing all instances including ones not created by cloud tasks
+
+         Job ID           ID                                                               Type            State       Zone            Created
+         -----------------------------------------------------------------------------------------------------------------------------------------------------------
+         N/A              personal-instance-1                                              e2-micro        running     us-central1-c   2025-04-28T14:33:46.974-07:00
+         my-job           rmscr-my-job-b2siduvm6a88og25yu5z76kkd                           e2-micro        terminated  us-central1-b   2025-04-28T14:22:01.786-07:00
+         my-job           rmscr-my-job-cjh38y7dttesfqkdbx4ew6kxb                           e2-micro        running     us-central1-a   2025-04-28T14:22:01.585-07:00
+
+         Summary: 3 total instances
+         2 running
+         1 terminated
+
+
+
+
+
 Queue Management Commands
 -------------------------
+
+.. _cli_monitor_event_queue:
+
+monitor_event_queue
+~~~~~~~~~~~~~~~~~~
+
+Monitor the event queue and display or save events as they arrive. This command continuously
+monitors the event queue for new messages and can optionally save them to a file.
+
+.. code-block:: none
+
+   cloud_tasks monitor_event_queue
+     [Common options]
+     [Provider-specific options]
+     [Additional options]
+
+Additional options:
+
+--output-file FILE    File to write events to (will be opened in append mode)
+
+Examples:
+
+.. tabs::
+
+   .. tab:: AWS
+
+      .. code-block:: none
+
+         XXX Update this
+         $ cloud_tasks monitor_event_queue --provider aws --job-id my-job --output-file events.json
+         Monitoring event queue 'my-job-events' on AWS...
+         {"event_type": "task_started", "task_id": "task-001", "timestamp": "2025-04-28T14:33:46.974Z"}
+         {"event_type": "task_completed", "task_id": "task-001", "timestamp": "2025-04-28T14:33:47.123Z"}
+
+   .. tab:: GCP
+
+      .. code-block:: none
+
+         $ cloud_tasks monitor_event_queue --provider gcp --job-id my-job --project my-project --output-file events.json
+         Monitoring event queue 'my-job-events' on GCP...
+         {"event_type": "task_started", "task_id": "task-001", "timestamp": "2025-04-28T14:33:46.974Z"}
+         {"event_type": "task_completed", "task_id": "task-001", "timestamp": "2025-04-28T14:33:47.123Z"}
+
 
 .. _load_queue_cmd:
 
@@ -806,6 +853,7 @@ Examples:
 
       .. code-block:: none
 
+         XXX Update this
          $ cloud_tasks purge_queue --provider aws --job-id my-job
 
          WARNING: This will permanently delete all 10000+ messages from queue 'my-job' on 'AWS'.
@@ -864,6 +912,12 @@ Examples:
          Deleting queue 'my-job' from AWS...
          Queue 'my-job' has been deleted.
 
+         WARNING: This will permanently delete the queue 'my-job-results' from AWS.
+         This operation cannot be undone and will remove all infrastructure.
+         Type 'DELETE my-job-results' to confirm: DELETE my-job-results
+         Deleting queue 'my-job-results' from AWS...
+         Queue 'my-job-results' has been deleted.
+
    .. tab:: GCP
 
       .. code-block:: none
@@ -875,6 +929,12 @@ Examples:
          Type 'DELETE my-job' to confirm: DELETE my-job
          Deleting queue 'my-job' from GCP...
          Queue 'my-job' has been deleted.
+
+         WARNING: This will permanently delete the queue 'my-job-results' from GCP.
+         This operation cannot be undone and will remove all infrastructure.
+         Type 'DELETE my-job-results' to confirm: DELETE my-job-results
+         Deleting queue 'my-job-results' from GCP...
+         Queue 'my-job-results' has been deleted.
 
 
 Exit Status

--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -118,7 +118,7 @@ RMS_CLOUD_TASKS_MAX_RUNTIME
 Tasks File
 ~~~~~~~~~~
 
---tasks TASKS_FILE      The name of a local file containing tasks to process; if not
+--task-file TASK_FILE   The name of a local file containing tasks to process; if not
                         specified, the worker will pull tasks from the cloud provider
                         queue (see below). The filename can also be a cloud storage
                         path like gs://bucket/file, s3://bucket/file, or

--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -85,6 +85,7 @@ line option or the ``RMS_CLOUD_TASKS_NO_RETRY_ON_CRASH`` environment variable.
 
 Note that if you are using a local task file, the task manager will never re-queue a task.
 
+
 .. _worker_environment_variables:
 
 Environment Variables and Command Line Arguments
@@ -137,20 +138,38 @@ Optional Parameters
 
 --project-id PROJECT_ID                    Project ID (required for GCP) [or ``RMS_CLOUD_TASKS_PROJECT_ID``]
 --queue-name QUEUE_NAME                    Name of the task queue to process (derived from job ID if not specified) [or ``RMS_CLOUD_TASKS_QUEUE_NAME``]
+--event-log-file EVENT_LOG_FILE            File to write events to; if not specified will not write events to a file [or ``RMS_CLOUD_TASKS_EVENT_LOG_FILE``]
+--event-log-to-queue                       If specified, events will be written to a cloud-based queue [or ``RMS_CLOUD_TASKS_EVENT_LOG_QUEUE`` is "1" or "true"]
+--no-event-log-to-queue                    If specified, events will not be written to a cloud-based queue [or ``RMS_CLOUD_TASKS_EVENT_LOG_QUEUE`` is "0" or "false"]
 --instance-type INSTANCE_TYPE              Instance type running on this computer [or ``RMS_CLOUD_TASKS_INSTANCE_TYPE``]
 --num-cpus N                               Number of vCPUs on this computer [or ``RMS_CLOUD_TASKS_INSTANCE_NUM_VCPUS``]
 --memory MEMORY_GB                         Memory in GB on this computer [or ``RMS_CLOUD_TASKS_INSTANCE_MEM_GB``]
 --local-ssd LOCAL_SSD_GB                   Local SSD in GB on this computer [or ``RMS_CLOUD_TASKS_INSTANCE_SSD_GB``]
 --boot-disk BOOT_DISK_GB                   Boot disk in GB on this computer [or ``RMS_CLOUD_TASKS_INSTANCE_BOOT_DISK_GB``]
---is-spot                                  Whether running on spot/preemptible instance [or ``RMS_CLOUD_TASKS_INSTANCE_IS_SPOT``]
+--is-spot                                  Whether running on spot/preemptible instance [or ``RMS_CLOUD_TASKS_INSTANCE_IS_SPOT`` is "1" or "true"]
+--no-is-spot                               Whether running on spot/preemptible instance [or ``RMS_CLOUD_TASKS_INSTANCE_IS_SPOT`` is "0" or "false"]
 --price PRICE_PER_HOUR                     Price per hour for the instance [or ``RMS_CLOUD_TASKS_INSTANCE_PRICE``]
 --num-simultaneous-tasks N                 Number of concurrent tasks to process (defaults to number of vCPUs, or 1 if not specified) [or ``RMS_CLOUD_TASKS_NUM_TASKS_PER_INSTANCE``]
 --max-runtime SECONDS                      Maximum runtime for a task in seconds [or ``RMS_CLOUD_TASKS_MAX_RUNTIME``] (default 3600 seconds)
 --shutdown-grace-period SECONDS            Time in seconds to wait for tasks to complete during shutdown [or ``RMS_CLOUD_TASKS_SHUTDOWN_GRACE_PERIOD``] (default 30 seconds)
 --tasks-to-skip TASKS_TO_SKIP              Number of tasks to skip before processing any from the queue [or ``RMS_CLOUD_TASKS_TO_SKIP``]
 --max-num-tasks MAX_NUM_TASKS              Maximum number of tasks to process [or ``RMS_CLOUD_TASKS_MAX_NUM_TASKS``]
+--retry-on-crash                           If specified, retry tasks on crash [or ``RMS_CLOUD_TASKS_RETRY_ON_CRASH`` is "1" or "true"]
+--no-retry-on-crash                        If specified, do not retry tasks on crash [or ``RMS_CLOUD_TASKS_RETRY_ON_CRASH`` is "0" or "false"]
 --simulate-spot-termination-after SECONDS  Number of seconds after worker start to simulate a spot termination notice [or ``RMS_CLOUD_TASKS_SIMULATE_SPOT_TERMINATION_AFTER``]
 --simulate-spot-termination-delay SECONDS  Number of seconds after a simulated spot termination notice to forcibly kill all running tasks [or ``RMS_CLOUD_TASKS_SIMULATE_SPOT_TERMINATION_DELAY``]
+--verbose                                  Set the console log level to DEBUG instead of INFO
+
+.. _worker_logging_events:
+
+Logging Events
+--------------
+
+Various events can be logged to a local file or a cloud-based queue. The events are written
+in a structured format that can be parsed by the pool manager or other software to update
+the status and results of the tasks.
+
+
 
 .. _worker_spot_instances:
 

--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -167,8 +167,49 @@ Logging Events
 
 Various events can be logged to a local file or a cloud-based queue. The events are written
 in a structured format that can be parsed by the pool manager or other software to update
-the status and results of the tasks.
+the status and results of the tasks. An example entry is:
 
+```json
+{"timestamp": "2025-05-26T01:56:26.321172",
+ "hostname": "rmscr-parallel-addition-job-0g23gxetnyyavtxjrul6gberr",
+ "event_type": "task_completed",
+ "task_id": "addition-task-009684",
+ "elapsed_time": 0.13359451293945312,
+ "retry": false,
+ "result": "Success!"
+}
+```
+
+The ``timestamp`` and ``hostname`` fields are always present.
+
+The ``event_type`` field can have the following values:
+
+- ``task_completed``: Indicates that the task completed normally. The ``task_id`` field will
+  contain the task ID as given in the task file. The ``retry`` and ``result``
+  fields will contain the values returned by the task function. The ``elapsed_time`` field
+  will contain the number of fractional seconds the task took to complete, including process
+  creation and destruction overhead.
+- ``task_timed_out``: Indicates that the task timed out (exceeded the time set by the
+  ``--max-runtime`` option). The ``task_id`` field will contain the task ID as given in the
+  task file. The ``elapsed_time`` field will contain the number of fractional seconds the
+  task ran before being killed.
+- ``task_exited``: Indicates that the task exited prematurely. The ``task_id`` field will
+  contain the task ID as given in the task file. The ``elapsed_time`` and ``exit_code``
+  fields will contain the number of seconds the task took to complete and the exit code of
+  the task, respectively.
+- ``non_fatal_exception``: Indicates that the task manager encountered an exception that
+  was deemed non-fatal and continued to run. The ``exception`` field will contain the
+  exception message. The ``stack_trace`` field will contain the stack trace of the exception.
+- ``fatal_exception``: Indicates that the task manager encountered an exception that
+  was deemed fatal and has exited. No further tasks will be processed and no events
+  collected or reported. If this occurred on a cloud-based compute instance, be aware that
+  the instance is now costing money without performing any work. The ``exception`` field
+  will contain the exception message. The ``stack_trace`` field will contain the stack
+  trace of the exception.
+- ``spot_termination``: Indicates that the worker received a spot termination notice.
+  No further tasks will be accepted and any existing tasks may be terminated prematurely
+  if the instance is destroyed before they finish. Any existing tasks that complete before
+  the instance is destroyed will have their results reported as usual.
 
 
 .. _worker_spot_instances:

--- a/examples/parallel_addition/config.yml
+++ b/examples/parallel_addition/config.yml
@@ -8,7 +8,6 @@ gcp:
     cd /root
     git clone https://github.com/SETI/rms-cloud-tasks.git
     cd rms-cloud-tasks
-    git checkout initial_version
     python3 -m venv venv
     source venv/bin/activate
     pip install -e .

--- a/examples/parallel_addition/config_with_secrets.yml
+++ b/examples/parallel_addition/config_with_secrets.yml
@@ -1,0 +1,22 @@
+provider: gcp
+
+gcp:
+  job_id: parallel-addition-job
+  project_id: rfrench
+  region: us-central1
+  boot_disk_types: [pd-standard, pd-ssd]
+  service_account: rms-cloud-run@rfrench.iam.gserviceaccount.com
+  startup_script: |
+    apt-get update -y
+    apt-get install -y python3 python3-pip python3-venv git
+    cd /root
+    git clone https://github.com/SETI/rms-cloud-tasks.git
+    cd rms-cloud-tasks
+    git checkout rf_250523
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -e .
+    pip install -r examples/parallel_addition/requirements.txt
+    export ADDITION_OUTPUT_DIR=gs://rfrench-test-bucket/addition-results
+    export ADDITION_TASK_DELAY=0
+    python3 examples/parallel_addition/worker_addition.py

--- a/examples/parallel_addition/worker_addition.py
+++ b/examples/parallel_addition/worker_addition.py
@@ -67,7 +67,7 @@ def process_task(task_id: str, task_data: Dict[str, Any], worker: Worker) -> Tup
             if worker.received_termination_notice:
                 f.write("*** Received spot termination signal ***\n")
 
-        return False, output_file
+        return False, "Success!"
 
     except Exception as e:
         # We still return False because we don't want to retry the task

--- a/examples/parallel_addition/worker_addition.py
+++ b/examples/parallel_addition/worker_addition.py
@@ -67,7 +67,7 @@ def process_task(task_id: str, task_data: Dict[str, Any], worker: Worker) -> Tup
             if worker.received_termination_notice:
                 f.write("*** Received spot termination signal ***\n")
 
-        return False, "Success!"
+        return False, str(output_file)
 
     except Exception as e:
         # We still return False because we don't want to retry the task

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -90,7 +90,7 @@ async def load_queue_cmd(args: argparse.Namespace, config: Config) -> None:
         if args.dry_run:
             print("Dry run mode enabled. No tasks will be loaded.")
         else:
-            print(f"Populating task queue from {args.tasks}...")
+            print(f"Populating task queue from {args.task_file}...")
         num_tasks = 0
         tasks_to_skip = args.start_task - 1 if args.start_task else 0
         tasks_remaining = args.limit
@@ -131,7 +131,7 @@ async def load_queue_cmd(args: argparse.Namespace, config: Config) -> None:
                     load_failed_exception = e
 
         with tqdm(desc="Enqueueing tasks") as pbar:
-            for task_num, task in enumerate(yield_tasks_from_file(args.tasks)):
+            for task_num, task in enumerate(yield_tasks_from_file(args.task_file)):
                 # Skip tasks until we reach the start_task
                 if tasks_to_skip > 0:
                     tasks_to_skip -= 1
@@ -1422,7 +1422,7 @@ def add_common_args(
 
 def add_load_queue_args(parser: argparse.ArgumentParser) -> None:
     """Add load queue specific arguments."""
-    parser.add_argument("--tasks", required=True, help="Path to tasks file (JSON or YAML)")
+    parser.add_argument("--task-file", required=True, help="Path to tasks file (JSON or YAML)")
     parser.add_argument(
         "--start-task", type=int, help="Skip tasks until this task number (1-based indexing)"
     )

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -225,9 +225,7 @@ async def show_queue_cmd(args: argparse.Namespace, config: Config) -> None:
         if args.detail:
             print("\nAttempting to peek at first message...")
             try:
-                messages = await task_queue.receive_tasks(
-                    max_count=1, visibility_timeout_seconds=10
-                )
+                messages = await task_queue.receive_tasks(max_count=1, visibility_timeout=10)
 
                 if messages:
                     message = messages[0]
@@ -695,8 +693,8 @@ async def run_job_cmd(args: argparse.Namespace, config: Config) -> None:
     Parameters:
         args: Command-line arguments
     """
-    load_queue_cmd(args, config)
-    manage_pool_cmd(args, config)
+    await load_queue_cmd(args, config)
+    await manage_pool_cmd(args, config)
 
 
 async def status_job_cmd(args: argparse.Namespace, config: Config) -> None:

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -1788,8 +1788,8 @@ def main():
     add_common_args(monitor_events_parser)
     monitor_events_parser.add_argument(
         "--output-file",
-        default="events.log",
-        help='File to write events to (will be opened in append mode); default is "events.log"',
+        required=True,
+        help="File to write events to (will be opened in append mode)",
     )
     monitor_events_parser.set_defaults(func=monitor_event_queue_cmd)
 

--- a/src/cloud_tasks/common/config.py
+++ b/src/cloud_tasks/common/config.py
@@ -219,6 +219,7 @@ class RunConfig(BaseModel, validate_assignment=True):
     scaling_check_interval: Optional[PositiveInt] = None
     instance_termination_delay: Optional[PositiveInt] = None
     max_runtime: Optional[PositiveInt] = None  # Use for queue timeout and workout task kill
+    retry_on_crash: Optional[bool] = None
 
 
 class ProviderConfig(RunConfig, validate_assignment=True):

--- a/src/cloud_tasks/instance_manager/instance_manager.py
+++ b/src/cloud_tasks/instance_manager/instance_manager.py
@@ -325,7 +325,7 @@ class InstanceManager(ABC):
         startup_script: str,
         job_id: str,
         use_spot: bool,
-        image: str,
+        image_uri: str,
         zone: Optional[str] = None,
     ) -> Tuple[str, str]:
         """
@@ -336,7 +336,7 @@ class InstanceManager(ABC):
             startup_script: The startup script
             job_id: Job ID to use for the instance
             use_spot: Whether to use a spot instance
-            image: Image to use
+            image_uri: Image URI to use
             zone: Zone to use for the instance; if not specified use the default zone,
                 or if none choose a random zone
 

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -222,6 +222,7 @@ export RMS_CLOUD_TASKS_PROVIDER={self._provider}
 {gcp_supplement}
 export RMS_CLOUD_TASKS_JOB_ID={self._job_id}
 export RMS_CLOUD_TASKS_QUEUE_NAME={self._queue_name}
+export RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE=1
 export RMS_CLOUD_TASKS_INSTANCE_TYPE={self._optimal_instance_info["name"]}
 export RMS_CLOUD_TASKS_INSTANCE_NUM_VCPUS={self._optimal_instance_info["vcpu"]}
 export RMS_CLOUD_TASKS_INSTANCE_MEM_GB={self._optimal_instance_info["mem_gb"]}
@@ -231,6 +232,7 @@ export RMS_CLOUD_TASKS_INSTANCE_IS_SPOT={self._run_config.use_spot}
 export RMS_CLOUD_TASKS_INSTANCE_PRICE={self._optimal_instance_info["total_price"]}
 export RMS_CLOUD_TASKS_NUM_TASKS_PER_INSTANCE={self._optimal_instance_num_tasks}
 export RMS_CLOUD_TASKS_MAX_RUNTIME={self._run_config.max_runtime}
+export RMS_CLOUD_TASKS_NO_RETRY_ON_CRASH={self._run_config.no_retry_on_crash}
 """
         if not self._run_config.startup_script:
             raise RuntimeError("No startup script provided")

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -232,7 +232,7 @@ export RMS_CLOUD_TASKS_INSTANCE_IS_SPOT={self._run_config.use_spot}
 export RMS_CLOUD_TASKS_INSTANCE_PRICE={self._optimal_instance_info["total_price"]}
 export RMS_CLOUD_TASKS_NUM_TASKS_PER_INSTANCE={self._optimal_instance_num_tasks}
 export RMS_CLOUD_TASKS_MAX_RUNTIME={self._run_config.max_runtime}
-export RMS_CLOUD_TASKS_NO_RETRY_ON_CRASH={self._run_config.no_retry_on_crash}
+export RMS_CLOUD_TASKS_RETRY_ON_CRASH={self._run_config.retry_on_crash}
 """
         if not self._run_config.startup_script:
             raise RuntimeError("No startup script provided")
@@ -774,7 +774,7 @@ export RMS_CLOUD_TASKS_NO_RETRY_ON_CRASH={self._run_config.no_retry_on_crash}
                             startup_script=startup_script,
                             job_id=self._job_id,
                             use_spot=self._run_config.use_spot,
-                            image=self._image_uri,
+                            image_uri=self._image_uri,
                             zone=self._optimal_instance_info["zone"],
                         )
                         self._logger.info(

--- a/src/cloud_tasks/queue_manager/__init__.py
+++ b/src/cloud_tasks/queue_manager/__init__.py
@@ -31,16 +31,16 @@ async def create_queue(config: Optional[Config] = None, **kwargs: Any) -> QueueM
                 # We import these here to avoid requiring the dependencies for unused providers
                 from .aws import AWSSQSQueue
 
-                queue: QueueManager = AWSSQSQueue(cast(AWSConfig, provider_config))
+                queue: QueueManager = AWSSQSQueue(cast(AWSConfig, provider_config), **kwargs)
             case "GCP":
                 from .gcp import GCPPubSubQueue
 
-                queue = GCPPubSubQueue(cast(GCPConfig, provider_config))
+                queue = GCPPubSubQueue(cast(GCPConfig, provider_config), **kwargs)
             case "AZURE":  # pragma: no cover
                 # TODO Implement Azure Service Bus queue
                 from .azure import AzureServiceBusQueue
 
-                queue = AzureServiceBusQueue(cast(AzureConfig, provider_config))
+                queue = AzureServiceBusQueue(cast(AzureConfig, provider_config), **kwargs)
             case _:  # pragma: no cover
                 # Can't get here because get_provider_config() raises an error
                 raise ValueError(f"Unsupported queue provider: {provider}")

--- a/src/cloud_tasks/queue_manager/aws.py
+++ b/src/cloud_tasks/queue_manager/aws.py
@@ -186,14 +186,14 @@ class AWSSQSQueue(QueueManager):
                 - 'data' (Dict[str, Any]): Message payload
                 - 'receipt_handle' (str): SQS receipt handle used for completing or failing the message
         """
+        # SQS limits max_count to 10
+        max_count = min(max_count, 10)
+
         self._logger.debug(f"Receiving up to {max_count} messages from queue '{self._queue_name}'")
 
         self._create_queue()
 
         try:
-            # SQS limits max_count to 10
-            max_count = min(max_count, 10)
-
             # Get the event loop
             loop = asyncio.get_event_loop()
 
@@ -252,6 +252,9 @@ class AWSSQSQueue(QueueManager):
                 - 'data' (Dict[str, Any]): Task payload/parameters
                 - 'receipt_handle' (str): SQS receipt handle used for completing or failing the task
         """
+        # SQS limits max_count to 10
+        max_count = min(max_count, 10)
+
         self._logger.debug(f"Receiving up to {max_count} tasks from queue '{self._queue_name}'")
 
         self._create_queue()

--- a/src/cloud_tasks/queue_manager/aws.py
+++ b/src/cloud_tasks/queue_manager/aws.py
@@ -237,14 +237,14 @@ class AWSSQSQueue(QueueManager):
     async def receive_tasks(
         self,
         max_count: int = 1,
-        visibility_timeout_seconds: int = 30,
+        visibility_timeout: int = 30,
     ) -> List[Dict[str, Any]]:
         """
         Receive tasks from the SQS queue.
 
         Args:
             max_count: Maximum number of messages to receive
-            visibility_timeout_seconds: Duration in seconds that messages are hidden
+            visibility_timeout: Duration in seconds that messages are hidden
 
         Returns:
             List of task dictionaries, each containing:
@@ -269,7 +269,7 @@ class AWSSQSQueue(QueueManager):
                 lambda: self._sqs.receive_message(
                     QueueUrl=self._queue_url,
                     MaxNumberOfMessages=max_count,
-                    VisibilityTimeout=visibility_timeout_seconds,
+                    VisibilityTimeout=visibility_timeout,
                     MessageAttributeNames=["All"],
                     WaitTimeSeconds=10,  # Using long polling
                 ),

--- a/src/cloud_tasks/queue_manager/azure.py
+++ b/src/cloud_tasks/queue_manager/azure.py
@@ -120,14 +120,14 @@ class AzureServiceBusQueue(QueueManager):
     async def receive_tasks(
         self,
         max_count: int = 1,
-        visibility_timeout_seconds: int = 30,  # TODO Default visibility timeout in seconds
+        visibility_timeout: int = 30,  # TODO Default visibility timeout in seconds
     ) -> List[Dict[str, Any]]:
         """
         Receive tasks from the Service Bus queue with a lock.
 
         Args:
             max_count: Maximum number of messages to receive
-            visibility_timeout_seconds: Duration in seconds for message lock
+            visibility_timeout: Duration in seconds for message lock
 
         Returns:
             List of task dictionaries with task_id, data, and lock_token
@@ -157,9 +157,7 @@ class AzureServiceBusQueue(QueueManager):
                     # Renew lock with the specified visibility timeout in a thread pool
                     await loop.run_in_executor(
                         None,
-                        lambda: receiver.renew_message_lock(
-                            message, timeout=visibility_timeout_seconds
-                        ),
+                        lambda: receiver.renew_message_lock(message, timeout=visibility_timeout),
                     )
 
                     tasks.append(

--- a/src/cloud_tasks/queue_manager/gcp.py
+++ b/src/cloud_tasks/queue_manager/gcp.py
@@ -245,6 +245,7 @@ class GCPPubSubQueue(QueueManager):
                 - 'data' (Dict[str, Any]): Message payload
                 - 'ack_id' (str): Pub/Sub acknowledgment ID used for completing or failing the message
         """
+        max_count = min(max_count, 1000)  # GCP limit
         self._logger.debug(f"Receiving up to {max_count} messages from queue '{self._queue_name}'")
 
         self._create_topic_subscription()
@@ -318,6 +319,7 @@ class GCPPubSubQueue(QueueManager):
                 - 'data' (Dict[str, Any]): Task payload/parameters
                 - 'ack_id' (str): Pub/Sub acknowledgment ID used for completing or failing the task
         """
+        max_count = min(max_count, 1000)  # GCP limit
         self._logger.debug(f"Receiving up to {max_count} tasks from queue '{self._queue_name}'")
 
         self._create_topic_subscription()

--- a/src/cloud_tasks/queue_manager/gcp.py
+++ b/src/cloud_tasks/queue_manager/gcp.py
@@ -303,14 +303,14 @@ class GCPPubSubQueue(QueueManager):
     async def receive_tasks(
         self,
         max_count: int = 1,
-        visibility_timeout_seconds: int = 30,
+        visibility_timeout: int = 30,
     ) -> List[Dict[str, Any]]:
         """
         Receive tasks from the Pub/Sub subscription.
 
         Args:
             max_count: Maximum number of messages to receive
-            visibility_timeout_seconds: Duration in seconds for ack deadline
+            visibility_timeout: Duration in seconds for ack deadline
 
         Returns:
             List of task dictionaries, each containing:
@@ -346,7 +346,7 @@ class GCPPubSubQueue(QueueManager):
                         request={
                             "subscription": self._subscription_path,
                             "ack_ids": [received_message.ack_id],
-                            "ack_deadline_seconds": visibility_timeout_seconds,
+                            "ack_deadline_seconds": visibility_timeout,
                         }
                     ),
                 )

--- a/src/cloud_tasks/queue_manager/queue_manager.py
+++ b/src/cloud_tasks/queue_manager/queue_manager.py
@@ -12,8 +12,18 @@ class QueueManager(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
+    async def send_message(self, message: Dict[str, Any]) -> None:
+        """Send a message to the queue."""
+        pass  # pragma: no cover
+
+    @abstractmethod
     async def send_task(self, task_id: str, task_data: Dict[str, Any]) -> None:
         """Send a task to the queue."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def receive_messages(self, max_count: int = 1) -> List[Dict[str, Any]]:
+        """Receive messages from the queue."""
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/cloud_tasks/queue_manager/queue_manager.py
+++ b/src/cloud_tasks/queue_manager/queue_manager.py
@@ -28,7 +28,7 @@ class QueueManager(ABC):
 
     @abstractmethod
     async def receive_tasks(
-        self, max_count: int = 1, visibility_timeout_seconds: int = 30
+        self, max_count: int = 1, visibility_timeout: int = 30
     ) -> List[Dict[str, Any]]:
         """Receive tasks from the queue with a visibility timeout."""
         pass  # pragma: no cover

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -1080,11 +1080,13 @@ class Worker:
                     for task in tasks:
                         if self._task_skip_count is not None and self._task_skip_count > 0:
                             self._task_skip_count -= 1
+                            logger.info("Skipping")
                             continue
                         if self._tasks_remaining is not None:
                             if self._tasks_remaining <= 0:
                                 break
                             self._tasks_remaining -= 1
+                            logger.info("Remaining tasks: %d", self._tasks_remaining)
 
                         async with self._process_ops_semaphore:
                             # Start a new process for this task

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -146,7 +146,7 @@ def _parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         type=int,
         help="Maximum allowed runtime in seconds; used to determine queue visibility "
         "timeout and to kill tasks that are running too long [overrides "
-        "$RMS_CLOUD_TASKS_MAX_RUNTIME] (default 3600 seconds)",
+        "$RMS_CLOUD_TASKS_MAX_RUNTIME] (default 600 seconds)",
     )
     parser.add_argument(
         "--shutdown-grace-period",
@@ -450,7 +450,7 @@ class Worker:
         if self._max_runtime is None:
             self._max_runtime = os.getenv("RMS_CLOUD_TASKS_MAX_RUNTIME")
         if self._max_runtime is None:
-            self._max_runtime = 3600  # Default to 1 hour
+            self._max_runtime = 600  # Default to 10 minutes
         else:
             self._max_runtime = int(self._max_runtime)
         logger.info(f"  Maximum runtime: {self._max_runtime} seconds")

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -52,7 +52,7 @@ def _parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         "--project-id", help="Project ID (required for GCP) [overrides $RMS_CLOUD_TASKS_PROJECT_ID]"
     )
     parser.add_argument(
-        "--tasks",
+        "--task-file",
         help="Path to JSON file containing tasks to process; if specified, cloud-based task "
         "queues are ignored",
     )
@@ -319,10 +319,10 @@ class Worker:
         # Get provider from args or environment variable
         self._provider = parsed_args.provider or os.getenv("RMS_CLOUD_TASKS_PROVIDER")
         if self._provider is None:
-            if not parsed_args.tasks:
+            if not parsed_args.task_file:
                 logger.error(
                     "Provider not specified via --provider or RMS_CLOUD_TASKS_PROVIDER "
-                    "and no tasks file specified via --tasks"
+                    "and no tasks file specified via --task-file"
                 )
                 sys.exit(1)
             if parsed_args.event_log_to_queue:
@@ -348,10 +348,10 @@ class Worker:
             self._queue_name = self._job_id
         logger.info(f"  Queue name: {self._queue_name}")
 
-        if self._queue_name is None and not parsed_args.tasks:
+        if self._queue_name is None and not parsed_args.task_file:
             logger.error(
                 "Queue name not specified via --queue-name or RMS_CLOUD_TASKS_QUEUE_NAME "
-                "or --job-id or RMS_CLOUD_TASKS_JOB_ID and no tasks file specified via --tasks"
+                "or --job-id or RMS_CLOUD_TASKS_JOB_ID and no tasks file specified via --task-file"
             )
             sys.exit(1)
 
@@ -501,7 +501,7 @@ class Worker:
                 )
 
         # Check if we're using a local tasks file
-        self._tasks_file = parsed_args.tasks
+        self._tasks_file = parsed_args.task_file
         if self._tasks_file:
             logger.info(f'  Using local tasks file: "{self._tasks_file}"')
 

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -7,12 +7,16 @@ It uses multiprocessing to achieve true parallelism across multiple CPU cores.
 
 import argparse
 import asyncio
+import datetime
+import json
 import json_stream
 import logging
 import os
 import signal
+import socket
 import sys
 import time
+import traceback
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Callable, Sequence
 import uuid
 import yaml
@@ -63,6 +67,25 @@ def _parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         "[overrides $RMS_CLOUD_TASKS_QUEUE_NAME]",
     )
     parser.add_argument(
+        "--event-log-file",
+        help="File to write events to; if not specified will not write events to a file "
+        "[overrides $RMS_CLOUD_TASKS_EVENT_LOG_FILE]",
+    )
+    parser.add_argument(
+        "--event-log-to-queue",
+        action="store_true",
+        default=None,
+        help="If specified, events will be written to a cloud-based queue "
+        "[overrides $RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE]",
+    )
+    parser.add_argument(
+        "--no-event-log-to-queue",
+        action="store_false",
+        dest="event_log_to_queue",
+        help="If specified, events will not be written to a cloud-based queue (default) "
+        "[overrides $RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE]",
+    )
+    parser.add_argument(
         "--instance-type",
         help="Instance type; optional information for the worker processes "
         "[overrides $RMS_CLOUD_TASKS_INSTANCE_TYPE]",
@@ -97,6 +120,14 @@ def _parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         default=None,
         help="If supported by the provider, specify that this is a spot instance and subject "
         "to unexpected termination [overrides $RMS_CLOUD_TASKS_INSTANCE_IS_SPOT]",
+    )
+    parser.add_argument(
+        "--no-is-spot",
+        action="store_false",
+        dest="is_spot",
+        help="If supported by the provider, specify that this is not a spot instance "
+        "and is not subject to unexpected termination (default) "
+        "[overrides $RMS_CLOUD_TASKS_INSTANCE_IS_SPOT]",
     )
     parser.add_argument(
         "--price",
@@ -134,11 +165,18 @@ def _parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Maximum number of tasks to process [overrides $RMS_CLOUD_TASKS_MAX_NUM_TASKS]",
     )
     parser.add_argument(
-        "--no-retry-on-crash",
+        "--retry-on-crash",
         action="store_true",
         default=None,
-        help="If specified, tasks will not be retried if the worker process crashes "
-        "[overrides $RMS_CLOUD_TASKS_NO_RETRY_ON_CRASH]",
+        help="If specified, tasks will be retried if the worker process (or user function) crashes "
+        "[overrides $RMS_CLOUD_TASKS_RETRY_ON_CRASH]",
+    )
+    parser.add_argument(
+        "--no-retry-on-crash",
+        action="store_false",
+        dest="retry_on_crash",
+        help="If specified, tasks will not be retried if the worker process (or user function) "
+        "crashes (default) [overrides $RMS_CLOUD_TASKS_RETRY_ON_CRASH]",
     )
     parser.add_argument(
         "--simulate-spot-termination-after",
@@ -152,6 +190,12 @@ def _parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Number of seconds after a simulated spot termination notice to forcibly kill "
         "all running tasks "
         "[overrides $RMS_CLOUD_TASKS_SIMULATE_SPOT_TERMINATION_DELAY]",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="If specified, set the log level to DEBUG",
     )
 
     return parser.parse_args(args)
@@ -267,16 +311,25 @@ class Worker:
         # Parse command line arguments if provided
         parsed_args = _parse_args(args)
 
+        if parsed_args.verbose:
+            logger.setLevel(logging.DEBUG)
+
         logger.info("Configuration:")
 
         # Get provider from args or environment variable
         self._provider = parsed_args.provider or os.getenv("RMS_CLOUD_TASKS_PROVIDER")
-        if self._provider is None and not parsed_args.tasks:
-            logger.error(
-                "Provider not specified via --provider or RMS_CLOUD_TASKS_PROVIDER "
-                "and no tasks file specified via --tasks"
-            )
-            sys.exit(1)
+        if self._provider is None:
+            if not parsed_args.tasks:
+                logger.error(
+                    "Provider not specified via --provider or RMS_CLOUD_TASKS_PROVIDER "
+                    "and no tasks file specified via --tasks"
+                )
+                sys.exit(1)
+            if parsed_args.event_log_to_queue:
+                logger.error(
+                    "--event-log-to-queue requires either --provider or RMS_CLOUD_TASKS_PROVIDER"
+                )
+                sys.exit(1)
         if self._provider is not None:
             self._provider = self._provider.upper()
         logger.info(f"  Provider: {self._provider}")
@@ -301,6 +354,28 @@ class Worker:
                 "or --job-id or RMS_CLOUD_TASKS_JOB_ID and no tasks file specified via --tasks"
             )
             sys.exit(1)
+
+        # Get event log file from args or environment variable
+        self._event_log_file = parsed_args.event_log_file or os.getenv(
+            "RMS_CLOUD_TASKS_EVENT_LOG_FILE"
+        )
+        logger.info(f"  Event log file: {self._event_log_file}")
+
+        self._event_log_to_queue = parsed_args.event_log_to_queue
+        if self._event_log_to_queue is None:
+            self._event_log_to_queue = os.getenv("RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE")
+            if self._event_log_to_queue is not None:
+                self._event_log_to_queue = self._event_log_to_queue.lower() in ("true", "1")
+        logger.info(f"  Event log to queue: {self._event_log_to_queue}")
+
+        self._event_log_queue_name = None
+        if self._event_log_to_queue:
+            if self._queue_name:
+                self._event_log_queue_name = f"{self._queue_name}-events"
+                logger.info(f"  Event log queue name: {self._event_log_queue_name}")
+            else:
+                logger.error("--event-log-to-queue requires either --job-id or --queue-name")
+                sys.exit(1)
 
         # Get instance type from args or environment variable
         self._instance_type = parsed_args.instance_type or os.getenv(
@@ -388,13 +463,13 @@ class Worker:
         )
         logger.info(f"  Shutdown grace period: {self._shutdown_grace_period} seconds")
 
-        # Get no retry on crash from args or environment variable
-        self._no_retry_on_crash = parsed_args.no_retry_on_crash
-        if self._no_retry_on_crash is None:
-            self._no_retry_on_crash = os.getenv("RMS_CLOUD_TASKS_NO_RETRY_ON_CRASH")
-            if self._no_retry_on_crash is not None:
-                self._no_retry_on_crash = self._no_retry_on_crash.lower() in ("true", "1")
-        logger.info(f"  No retry on crash: {self._no_retry_on_crash}")
+        # Get retry on crash from args or environment variable
+        self._retry_on_crash = parsed_args.retry_on_crash
+        if self._retry_on_crash is None:
+            self._retry_on_crash = os.getenv("RMS_CLOUD_TASKS_RETRY_ON_CRASH")
+            if self._retry_on_crash is not None:
+                self._retry_on_crash = self._retry_on_crash.lower() in ("true", "1")
+        logger.info(f"  Retry on crash: {self._retry_on_crash}")
 
         # Get simulate spot termination after from args or environment variable
         self._simulate_spot_termination_after = parsed_args.simulate_spot_termination_after
@@ -459,8 +534,8 @@ class Worker:
 
         # Track processes
         self._processes: Dict[int, Dict[str, Any]] = {}  # Maps worker # to process and task
-        self._num_tasks_succeeded: int = 0
-        self._num_tasks_failed: int = 0
+        self._num_tasks_not_retried: int = 0
+        self._num_tasks_retried: int = 0
         self._num_tasks_timed_out: int = 0
 
         # Task queue for inter-process communication
@@ -473,6 +548,10 @@ class Worker:
         # Register signal handlers
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
+
+        self._hostname = socket.gethostname()
+        self._event_logger_fp = None
+        self._event_logger_queue = None
 
     @property
     def provider(self) -> str | None:
@@ -557,29 +636,115 @@ class Worker:
     def _signal_handler(self, signum, frame):
         """Handle termination signals."""
         signal_name = signal.Signals(signum).name
-        logger.info(f"Received signal {signal_name}, initiating graceful shutdown")
+        logger.warning(f"Received signal {signal_name}, initiating graceful shutdown")
         self._shutdown_event.set()
         signal.signal(signal.SIGINT, signal.SIG_DFL)  # So a second time will kill the process
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
-    async def start(self) -> None:
-        """Start the worker and begin processing tasks.
+    _EVENT_TYPE_TASK_COMPLETED = "task_completed"
+    _EVENT_TYPE_TASK_TIMED_OUT = "task_timed_out"
+    _EVENT_TYPE_TASK_EXITED = "task_exited"
+    _EVENT_TYPE_NON_FATAL_EXCEPTION = "non_fatal_exception"
+    _EVENT_TYPE_FATAL_EXCEPTION = "fatal_exception"
+    _EVENT_TYPE_SPOT_TERMINATION = "spot_termination"
 
-        This method will:
-        1. Initialize the task queue connection
-        2. Start worker processes
-        3. Begin task processing
-        4. Run until shutdown is requested
-        """
+    def _log_event(self, event: Dict[str, Any]) -> None:
+        """Log an event to the event log."""
+        event["timestamp"] = datetime.datetime.now().isoformat()
+        event["hostname"] = self._hostname
+        if self._event_logger_fp:
+            self._event_logger_fp.write(json.dumps(event) + "\n")
+            self._event_logger_fp.flush()
+        if self._event_logger_queue:
+            self._event_logger_queue.send_message(json.dumps(event))
+
+    def _log_task_completed(
+        self, task_id: str, *, elapsed_time: float, retry: bool, result: Any
+    ) -> None:
+        """Log a task completed event."""
+        self._log_event(
+            {
+                "event_type": self._EVENT_TYPE_TASK_COMPLETED,
+                "task_id": task_id,
+                "elapsed_time": elapsed_time,
+                "retry": retry,
+                "result": result,
+            }
+        )
+
+    def _log_task_timed_out(self, task_id: str, runtime: float) -> None:
+        """Log a task timed out event."""
+        self._log_event(
+            {
+                "event_type": self._EVENT_TYPE_TASK_TIMED_OUT,
+                "task_id": task_id,
+                "elapsed_time": runtime,
+            }
+        )
+
+    def _log_task_exited(self, task_id: str, exit_code: int) -> None:
+        """Log a task exited event."""
+        self._log_event(
+            {
+                "event_type": self._EVENT_TYPE_TASK_EXITED,
+                "task_id": task_id,
+                "exit_code": exit_code,
+            }
+        )
+
+    def _log_non_fatal_exception(self, exception: Exception) -> None:
+        """Log a non-fatal exception event."""
+        self._log_event(
+            {"event_type": self._EVENT_TYPE_NON_FATAL_EXCEPTION, "exception": str(exception)}
+        )
+
+    def _log_fatal_exception(self, exception: Exception) -> None:
+        """Log a fatal exception event."""
+        self._log_event(
+            {
+                "event_type": self._EVENT_TYPE_FATAL_EXCEPTION,
+                "exception": str(exception),
+                "stack_trace": traceback.format_exc(),
+            }
+        )
+
+    def _log_spot_termination(self) -> None:
+        """Log a spot termination event."""
+        self._log_event({"event_type": self._EVENT_TYPE_SPOT_TERMINATION})
+
+    async def start(self) -> None:
+        """Start the worker and begin processing tasks."""
+
+        if self._event_log_file:
+            logger.debug(f'Starting event logger for file "{self._event_log_file}"')
+            try:
+                self._event_logger_fp = open(self._event_log_file, "a")
+            except Exception as e:
+                logger.error(f"Error opening event log file: {e}", exc_info=True)
+                sys.exit(1)
+
+        if self._event_log_to_queue:
+            logger.debug(f'Starting event logger for queue "{self._event_log_queue_name}"')
+            try:
+                self._event_logger_queue = await create_queue(
+                    provider=self._provider,
+                    queue_name=self._event_log_queue_name,
+                    project_id=self._project_id,
+                )
+            except Exception as e:
+                logger.error(f"Error initializing event log queue: {e}", exc_info=True)
+                sys.exit(1)
+
         if self._tasks_file:
-            logger.info(f'Starting task scheduler for local tasks file "{self._tasks_file}"')
+            logger.debug(f'Starting task scheduler for local tasks file "{self._tasks_file}"')
             try:
                 self._task_queue = LocalTaskQueue(self._tasks_file)
             except Exception as e:
                 logger.error(f"Error initializing local task queue: {e}", exc_info=True)
+                self._log_fatal_exception(e)
                 sys.exit(1)
         else:
-            logger.info(
+            logger.debug(
                 f"Starting task scheduler for {self._provider.upper()} queue "
                 f'"{self._queue_name}"'
             )
@@ -591,6 +756,7 @@ class Worker:
                 )
             except Exception as e:
                 logger.error(f"Error initializing task queue: {e}", exc_info=True)
+                self._log_fatal_exception(e)
                 sys.exit(1)
 
         self._start_time = time.time()
@@ -612,48 +778,110 @@ class Worker:
         # Process tasks until shutdown
         await self._wait_for_shutdown()
 
-        total = self._num_tasks_succeeded + self._num_tasks_failed + self._num_tasks_timed_out
+        total = self._num_tasks_not_retried + self._num_tasks_retried + self._num_tasks_timed_out
         logger.info(
-            f"Task scheduler shutdown complete. Succeeded: {self._num_tasks_succeeded}, "
-            f"Failed: {self._num_tasks_failed}, Timed out: {self._num_tasks_timed_out}, "
+            f"Task scheduler shutdown complete. Not retried: {self._num_tasks_not_retried}, "
+            f"Retried: {self._num_tasks_retried}, Timed out: {self._num_tasks_timed_out}, "
             f"Total: {total}"
         )
+        # We don't log an event here because this only happens when the user hits Ctrl-C
 
     async def _handle_results(self) -> None:
         """Handle results from worker processes."""
         while self._running:
             try:
-                # Use asyncio to check the queue without blocking
-                while not self._result_queue.empty():
-                    worker_id, retry, result = self._result_queue.get_nowait()
-                    async with self._process_ops_semaphore:
+                # We primarily look for processes that have exited. Once we find one,
+                # we check the result queue to find the results from that process. If the
+                # results aren't there, then the process exited prematurely.
+                # Update the number of active processes in case one of them has exited
+                # prematurely
+                async with self._process_ops_semaphore:
+                    exited_processes = {}
+                    for worker_id, process_data in self._processes.items():
+                        p = process_data["process"]
+                        if not p.is_alive():
+                            logger.debug(f"Worker #{worker_id} (PID {p.pid}) has exited")
+                            exited_processes[worker_id] = process_data
+
+                    # Now go through the result queue
+                    while not self._result_queue.empty():
+                        worker_id, retry, result = self._result_queue.get_nowait()
+
                         if worker_id not in self._processes:
                             # Race condition with max_runtime most likely
-                            logger.warning(
-                                f"Worker #{worker_id} reported task completed but "
-                                "task had already timed out and was being terminated; "
-                                "it was marked as completed and will not be retried"
+                            logger.debug(
+                                f"Worker #{worker_id} report results but process had previously "
+                                "exited; this is probably due to a race condition with "
+                                "max_runtime and should be ignored"
                             )
                             continue
+
                         process_data = self._processes[worker_id]
+                        p = process_data["process"]
                         task = process_data["task"]
 
+                        if worker_id not in exited_processes:
+                            # We caught this process between the time it sent a result and the
+                            # time it exited. It's possible it's wedged, or that we were
+                            # just lucky. Either way, we'll kill it off just to be safe.
+                            p.kill()
+
+                        elapsed_time = time.time() - process_data["start_time"]
                         if retry:
-                            self._num_tasks_succeeded += 1
+                            self._num_tasks_retried += 1
                             logger.info(
                                 f"Worker #{worker_id} reported task {task['task_id']} completed "
-                                f"with no retry - {result}"
+                                f"in {elapsed_time:.1f} seconds but will be retried; result: {result}"
                             )
-                            async with self._task_queue_semaphore:
-                                await self._task_queue.complete_task(task["ack_id"])
-                        else:
-                            self._num_tasks_failed += 1
-                            logger.error(
-                                f"Worker #{worker_id} reported task {task['task_id']} completed "
-                                f"with retry - {result}"
+                            self._log_task_completed(
+                                task["task_id"],
+                                elapsed_time=elapsed_time,
+                                retry=True,
+                                result=result,
                             )
                             async with self._task_queue_semaphore:
                                 await self._task_queue.fail_task(task["ack_id"])
+                        else:
+                            self._num_tasks_not_retried += 1
+                            logger.info(
+                                f"Worker #{worker_id} reported task {task['task_id']} completed "
+                                f"in {elapsed_time:.1f} seconds with no retry; result: {result}"
+                            )
+                            self._log_task_completed(
+                                task["task_id"],
+                                elapsed_time=elapsed_time,
+                                retry=False,
+                                result=result,
+                            )
+                            async with self._task_queue_semaphore:
+                                await self._task_queue.complete_task(task["ack_id"])
+
+                        del self._processes[worker_id]
+                        if worker_id in exited_processes:
+                            del exited_processes[worker_id]
+
+                    # Check for processes that exited prematurely; we didn't get result messages
+                    # from these
+                    for worker_id, process_data in exited_processes.items():
+                        try:
+                            exit_code = process_data["process"].exitcode
+                        except Exception:
+                            exit_code = None
+                        task = process_data["task"]
+                        logger.warning(
+                            f"Worker #{worker_id} (PID {p.pid}) processing task "
+                            f'"{task["task_id"]}" exited prematurely with exit code '
+                            f"{exit_code}"
+                        )
+                        self._log_task_exited(task["task_id"], exit_code)
+
+                        async with self._task_queue_semaphore:
+                            if self._retry_on_crash:
+                                # If we're retrying on crash, mark it as failed
+                                await self._task_queue.fail_task(task["ack_id"])
+                            else:
+                                # If we're not retrying on crash, mark it as complete
+                                await self._task_queue.complete_task(task["ack_id"])
 
                         del self._processes[worker_id]
 
@@ -662,6 +890,7 @@ class Worker:
 
             except Exception as e:
                 logger.error(f"Error handling results: {e}", exc_info=True)
+                self._log_non_fatal_exception(e)
                 await asyncio.sleep(1)  # Wait a bit longer on error
 
     async def _wait_for_shutdown(self, interval: float = 0.5) -> None:
@@ -717,6 +946,7 @@ class Worker:
                 if termination_notice and not self.received_termination_notice:
                     logger.warning("Instance termination notice received")
                     self._termination_event.set()
+                    self._log_spot_termination()
                     # When the termination actually occurs, we don't need to do anything;
                     # this instance will simply stop running. If the workers were in the
                     # middle of doing something, they will be aborted at a random point.
@@ -726,7 +956,7 @@ class Worker:
 
             except Exception as e:
                 logger.error(f"Error checking for termination: {e}", exc_info=True)
-
+                self._log_non_fatal_exception(e)
             # Check every 5 seconds for real instance, .1 second for simulated
             if self._simulate_spot_termination_after is not None:
                 await asyncio.sleep(0.1)
@@ -813,30 +1043,9 @@ class Worker:
         """Fetch tasks from the cloud queue and feed them to worker processes."""
         while self._running:
             try:
-                # Update the number of active processes in case one of them has exited
-                # prematurely
-                async with self._process_ops_semaphore:
-                    exited_worker_ids = []
-                    for worker_id, process_data in self._processes.items():
-                        p = process_data["process"]
-                        if not p.is_alive():
-                            logger.warning(f"Worker #{worker_id} (PID {p.pid}) exited prematurely")
-                            task = process_data["task"]
-                            async with self._task_queue_semaphore:
-                                if self._no_retry_on_crash:
-                                    # If we're not retrying on crash, mark it as complete
-                                    await self._task_queue.complete_task(task["ack_id"])
-                                else:
-                                    # Otherwise, set it to try again somewhere else
-                                    await self._task_queue.fail_task(task["ack_id"])
-                            exited_worker_ids.append(worker_id)
-                    # Do this separately so we don't modify the dictionary while iterating
-                    for worker_id in exited_worker_ids:
-                        del self._processes[worker_id]
-
                 if self.received_shutdown_request or self.received_termination_notice:
                     # If we're shutting down for any reason, don't start any new tasks
-                    await asyncio.sleep(1)  # Wait a bit longer on error
+                    await asyncio.sleep(1)
                     continue
 
                 # Only fetch new tasks if we have capacity
@@ -855,7 +1064,6 @@ class Worker:
 
                 if tasks:
                     for task in tasks:
-                        print(self._task_skip_count, self._tasks_remaining)
                         if self._task_skip_count is not None and self._task_skip_count > 0:
                             self._task_skip_count -= 1
                             continue
@@ -867,8 +1075,8 @@ class Worker:
                         async with self._process_ops_semaphore:
                             # Start a new process for this task
                             worker_id = (
-                                self._num_tasks_succeeded
-                                + self._num_tasks_failed
+                                self._num_tasks_not_retried
+                                + self._num_tasks_retried
                                 + self._num_tasks_timed_out
                                 + len(self._processes)
                             )
@@ -892,9 +1100,7 @@ class Worker:
                                 "start_time": time.time(),
                                 "task": task,
                             }
-                            logger.info(
-                                f"Started single-task worker #{worker_id} " f"(PID {p.pid})"
-                            )
+                            logger.info(f"Started single-task worker #{worker_id} (PID {p.pid})")
                             logger.debug(
                                 f"Queued task {task['task_id']}, active tasks: "
                                 f"{len(self._processes)}"
@@ -905,6 +1111,7 @@ class Worker:
 
             except Exception as e:
                 logger.error(f"Error fetching tasks: {e}", exc_info=True)
+                self._log_non_fatal_exception(e)
                 await asyncio.sleep(1)  # Wait a bit longer on error
 
     async def _monitor_process_runtimes(self) -> None:
@@ -914,6 +1121,7 @@ class Worker:
             killed_one = False
 
             # Check each process's runtime
+            processes_to_delete = []
             async with self._process_ops_semaphore:
                 for worker_id, process_data in self._processes.items():
                     start_time = process_data["start_time"]
@@ -926,12 +1134,13 @@ class Worker:
                     logger.warning(
                         f"Worker #{worker_id} (PID {p.pid}), task "
                         f"{process_data['task']['task_id']} exceeded max runtime of "
-                        f"{self._max_runtime} seconds (actual runtime {runtime:.1f} seconds)"
+                        f"{self._max_runtime} seconds (actual runtime {runtime:.1f} seconds); "
+                        "terminating"
                     )
+                    self._log_task_timed_out(task["task_id"], runtime)
 
                     # Kill the process that exceeded runtime
                     try:
-                        logger.info(f"Terminating worker #{worker_id} (PID {p.pid})")
                         p.terminate()
                         p.join(timeout=1)
                         if p.is_alive():
@@ -944,6 +1153,7 @@ class Worker:
                         logger.error(
                             f"Error terminating process worker #{worker_id} (PID " f"{p.pid}): {e}"
                         )
+                        self._log_non_fatal_exception(e)
 
                     # Mark task as failed in the queue
                     try:
@@ -955,16 +1165,15 @@ class Worker:
                             await self._task_queue.complete_task(task["ack_id"])
                     except Exception as e:
                         logger.error(f"Error marking task {task['task_id']} as completed: {e}")
+                        self._log_non_fatal_exception(e)
 
                     # Remove from tracking
-                    del self._processes[worker_id]
+                    processes_to_delete.append(worker_id)
                     self._num_tasks_timed_out += 1
                     killed_one = True
 
-                    break
-
-                if killed_one:
-                    continue
+                for worker_id in processes_to_delete:
+                    del self._processes[worker_id]
 
             await asyncio.sleep(1)  # Check every second
 
@@ -1022,12 +1231,13 @@ class Worker:
                     f"Worker #{worker_id}: Error executing task {task_id}: {e}", exc_info=True
                 )
                 # Send failure back to main process
-                result_queue.put((worker_id, worker._no_retry_on_crash, str(e)))
+                result_queue.put((worker_id, worker._retry_on_crash, str(e)))
 
         except Exception as e:
             logger.error(f"Worker #{worker_id}: Unhandled error - {e}", exc_info=True)
 
         logger.info(f"Worker #{worker_id}: Exiting")
+        sys.exit(0)
 
     @staticmethod
     def _execute_task_isolated(

--- a/tests/cloud_tasks/queue_manager/test_aws.py
+++ b/tests/cloud_tasks/queue_manager/test_aws.py
@@ -108,7 +108,7 @@ async def test_receive_tasks(aws_queue, mock_sqs_client):
     }
 
     # Receive tasks
-    tasks = await aws_queue.receive_tasks(max_count=2, visibility_timeout_seconds=60)
+    tasks = await aws_queue.receive_tasks(max_count=2, visibility_timeout=60)
 
     # Verify receive_message was called
     mock_sqs_client.receive_message.assert_called_with(

--- a/tests/cloud_tasks/queue_manager/test_gcp.py
+++ b/tests/cloud_tasks/queue_manager/test_gcp.py
@@ -144,7 +144,7 @@ async def test_receive_tasks(gcp_queue, mock_pubsub_client):
     mock_subscriber.pull.return_value = mock_response
 
     # Receive tasks
-    tasks = await gcp_queue.receive_tasks(max_count=2, visibility_timeout_seconds=60)
+    tasks = await gcp_queue.receive_tasks(max_count=2, visibility_timeout=60)
 
     # Verify pull was called
     mock_subscriber.pull.assert_called_with(

--- a/tests/cloud_tasks/worker/test_worker.py
+++ b/tests/cloud_tasks/worker/test_worker.py
@@ -329,7 +329,7 @@ def test_num_simultaneous_tasks_default(mock_worker_function):
             args = types.SimpleNamespace(
                 provider="AWS",
                 project_id=None,
-                tasks=None,
+                task_file=None,
                 job_id="jid",
                 queue_name=None,
                 instance_type=None,
@@ -360,7 +360,7 @@ def test_num_simultaneous_tasks_default(mock_worker_function):
             args = types.SimpleNamespace(
                 provider="AWS",
                 project_id=None,
-                tasks=None,
+                task_file=None,
                 job_id="jid",
                 queue_name=None,
                 instance_type=None,
@@ -395,7 +395,7 @@ def test_provider_required_without_tasks(mock_worker_function, caplog):
                 args = types.SimpleNamespace(
                     provider=None,
                     project_id=None,
-                    tasks=None,
+                    task_file=None,
                     job_id="test-job",
                     queue_name=None,
                     instance_type=None,
@@ -421,7 +421,7 @@ def test_provider_required_without_tasks(mock_worker_function, caplog):
                     Worker(mock_worker_function)
                     mock_exit.assert_called_once_with(1)
                     assert (
-                        "Provider not specified via --provider or RMS_CLOUD_TASKS_PROVIDER and no tasks file specified via --tasks"
+                        "Provider not specified via --provider or RMS_CLOUD_TASKS_PROVIDER and no tasks file specified via --task-file"
                         in caplog.text
                     )
 
@@ -429,12 +429,12 @@ def test_provider_required_without_tasks(mock_worker_function, caplog):
 def test_provider_not_required_with_tasks(mock_worker_function):
     """Test that provider is not required when tasks file is specified."""
     with patch.dict(os.environ, {}, clear=True):
-        with patch("sys.argv", ["worker.py", "--tasks", "tasks.json"]):
+        with patch("sys.argv", ["worker.py", "--task-file", "tasks.json"]):
             with patch("cloud_tasks.worker.worker._parse_args") as mock_parse_args:
                 args = types.SimpleNamespace(
                     provider=None,
                     project_id=None,
-                    tasks="tasks.json",
+                    task_file="tasks.json",
                     job_id=None,
                     queue_name=None,
                     instance_type=None,
@@ -463,7 +463,7 @@ def test_provider_not_required_with_tasks(mock_worker_function):
 
 @pytest.mark.asyncio
 async def test_start_with_local_tasks(mock_worker_function, local_tasks_file_json):
-    with patch("sys.argv", ["worker.py", "--tasks", local_tasks_file_json]):
+    with patch("sys.argv", ["worker.py", "--task-file", local_tasks_file_json]):
         worker = Worker(mock_worker_function)
         with patch.object(worker, "_wait_for_shutdown") as mock_wait:
             mock_wait.side_effect = asyncio.CancelledError()
@@ -707,7 +707,7 @@ def test_exit_if_no_job_id_and_no_tasks(mock_worker_function, caplog):
                 args = types.SimpleNamespace(
                     provider="AWS",
                     project_id=None,
-                    tasks=None,
+                    task_file=None,
                     job_id=None,
                     queue_name=None,
                     instance_type=None,
@@ -735,7 +735,7 @@ def test_exit_if_no_job_id_and_no_tasks(mock_worker_function, caplog):
                         Worker(mock_worker_function)
                         mock_exit.assert_called_once_with(1)
                         assert (
-                            "Queue name not specified via --queue-name or RMS_CLOUD_TASKS_QUEUE_NAME or --job-id or RMS_CLOUD_TASKS_JOB_ID and no tasks file specified via --tasks"
+                            "Queue name not specified via --queue-name or RMS_CLOUD_TASKS_QUEUE_NAME or --job-id or RMS_CLOUD_TASKS_JOB_ID and no tasks file specified via --task-file"
                             in caplog.text
                         )
 
@@ -746,7 +746,7 @@ def test_worker_properties(mock_worker_function):
             args = types.SimpleNamespace(
                 provider="AWS",
                 project_id="pid",
-                tasks=None,
+                task_file=None,
                 job_id="jid",
                 queue_name="qname",
                 instance_type="itype",
@@ -792,7 +792,7 @@ def test_signal_handler(mock_worker_function, caplog):
             args = types.SimpleNamespace(
                 provider="AWS",
                 project_id=None,
-                tasks=None,
+                task_file=None,
                 job_id="jid",
                 queue_name=None,
                 instance_type=None,
@@ -1418,7 +1418,7 @@ async def test_handle_results_process_exit_retry_on_crash(mock_worker_function):
 
 
 @pytest.mark.asyncio
-async def test_event_logging_to_file(mock_worker_function, tmp_path):
+async def test_event_logging_to_file(mock_worker_function, tmp_path, local_tasks_file_json):
     """Test event logging to file for various event types."""
     event_log_file = tmp_path / "events.log"
 
@@ -1432,6 +1432,8 @@ async def test_event_logging_to_file(mock_worker_function, tmp_path):
             "test-job",
             "--event-log-file",
             str(event_log_file),
+            "--task-file",
+            str(local_tasks_file_json),
         ],
     ):
         worker = Worker(mock_worker_function)


### PR DESCRIPTION
- Queue manager:
  - Add `send_message` and `receive_messages`
- CLI
  - Add `monitor_event_queue` command
  - Update `purge_queue` and `delete_queue` to handle both the task and event queues
  - Rename `--tasks` to `--task-file`
- Worker
  - Add options `--event-log-file`, `--event-log-to-queue`, `--no-event-log-to-queue`
    - Added logging of events to a file or queue
  - Add option `--no-is-spot`
  - Add option `--no-retry-on-crash`
  - Add option `--verbose`
  - Rename `--tasks` to `--task-file`
  - Various bug fixes
- Documentation
  - Add `monitor_event_queue` command
  - Add options for `purge_queue` and `delete_queue`
  - Change `--tasks` to `--task-file`
