### PR TITLE
Fix GCP visibility timeout; add worker health monitoring, per-task memory limits, and run diagnostics

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -549,6 +549,28 @@ status and events. It contains:
 - Exception summaries with counts
 - Spot termination tracking
 
+**Instance Detail Table**: With debug logging enabled (``-vv`` or more, e.g. ``-vvv``), each
+time the periodic scaling check computes the running-instance summary it first logs a table
+with one row per instance, giving the instance's ID, type, state, zone, creation time, how
+long ago its last keep-alive event arrived, and its keep-alive status. This makes it possible
+to see exactly which instance the manager considers overdue, and by how much, before it is
+terminated:
+
+.. code-block:: none
+
+   Instance details:
+     Instance ID              Type            State     Zone           Created              Keep-Alive  Status
+     --------------------------------------------------------------------------------------------------------------------------------------------------------
+     my-job-1riovtucuu1o1dx9  n2-highcpu-4    running   us-central1-f  2026-08-18T13:47:46  45s ago     OK (255s until overdue)
+     my-job-2b77c9e4a1f0d3b8  n2-highcpu-4    starting  us-central1-f  2026-08-18T14:18:00  never       awaiting first keep-alive (120s of 600s)
+     my-job-8ad4013f9c22e7a5  n2-standard-16  running   us-central1-b  2026-08-18T13:58:00  never       OVERDUE by 600s for its first keep-alive (limit 600s)
+     my-job-c1902e77bb410fa6  n2-highcpu-4    running   us-central1-f  2026-08-18T13:28:00  900s ago    OVERDUE by 600s (limit 300s)
+
+The keep-alive columns read ``not monitored`` when keep-alive monitoring isn't running, which
+is the case when both keep-alive timeouts are disabled, during a ``--dry-run``, and for the
+:ref:`cli_status_cmd` command (which only queries instances and so never receives keep-alive
+events).
+
 Examples:
 
 .. tabs::

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -513,7 +513,9 @@ Additional options:
 --db-file DB_FILE                     Path to SQLite database file (default: {job_id}.db);
                                       can also be set in configuration file under run.db_file
 --output-file OUTPUT_FILE             Optional file to write events to in JSON-lines format
-                                      in addition to the SQLite database
+                                      in addition to the SQLite database; the file is appended
+                                      to, and with --continue a file that does not yet exist is
+                                      first seeded with the events already in the database
 --force, -f                           Force fresh run without confirmation even if queue has
                                       existing messages
 --dry-run                             Do not actually load any tasks or create or delete any
@@ -525,6 +527,16 @@ status and events. It contains:
 - **tasks table**: task_id, task_data, status, retry flag, timestamps, hostname, results,
   exceptions, exit codes
 - **events table**: Raw event log from workers
+
+**Event Log File**: ``--output-file`` writes every received event to a file in JSON-lines
+format, in addition to the SQLite database. The file is opened for append, so resuming a job
+with ``--continue`` extends the existing log rather than truncating it. If the file does not
+exist yet — because the earlier part of the job ran without ``--output-file``, or the file was
+moved away — a ``--continue`` run first writes out the events already recorded in the database,
+so the result is a complete log of the whole job rather than only the part this process
+observed. An output file that already exists is never re-seeded, since its contents are presumed
+to already cover those events; otherwise every resume would duplicate the entire history.
+Keep-alive events are not stored in the database and never appear in the log.
 
 **Task Completion**: A task is considered complete when it has any status with ``retry=False``.
 
@@ -622,7 +634,9 @@ this does not manage compute instances.
 Additional options:
 
 --db-file DB_FILE                     Path to SQLite database file (default: {job_id}.db)
---output-file OUTPUT_FILE             Optional file to write events to in JSON-lines format
+--output-file OUTPUT_FILE             Optional file to write events to in JSON-lines format; the
+                                      file is appended to, and one that does not yet exist is
+                                      first seeded with the events already in the database
 --print-events                        Print events to stdout as they are received
 --no-auto-complete                    Don't stop automatically when all tasks complete
 
@@ -662,7 +676,9 @@ testing or debugging) but still use the automated event monitoring and task trac
 - Updates the database with task status, results, and statistics
 - Prints periodic status summaries to the console
 - Automatically stops when all tasks complete (unless ``--no-auto-complete`` is specified)
-- Optionally writes events to a JSON-lines output file for archival
+- Optionally writes events to a JSON-lines output file for archival; because this command
+  always attaches to a job that is already under way, an output file that does not yet exist
+  is first seeded with the events already in the database
 
 **Comparison with ``run`` command:**
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -203,6 +203,11 @@ options in the configuration file (see :ref:`config_worker_and_manage_pool_optio
                                        maximum runtime specified by --max-runtime
 --no-retry-on-timeout                  If specified, tasks will not be retried if they exceed the
                                        maximum runtime specified by --max-runtime (default)
+--max-memory-allowed-per-task GB       The maximum memory in GB each task process is allowed to
+                                       use, enforced by the OS as an address-space limit on the
+                                       process; a task that exceeds it fails with a MemoryError
+                                       and is not retried; passed to the workers via the startup
+                                       script (defaults to no limit)
 --keepalive-interval SECONDS           The interval between worker keep-alive events; passed to
                                        the workers via the startup script (defaults to 60)
 --keepalive-startup-timeout SECONDS    How long to wait after an instance is started for its

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -203,6 +203,16 @@ options in the configuration file (see :ref:`config_worker_and_manage_pool_optio
                                        maximum runtime specified by --max-runtime
 --no-retry-on-timeout                  If specified, tasks will not be retried if they exceed the
                                        maximum runtime specified by --max-runtime (default)
+--keepalive-interval SECONDS           The interval between worker keep-alive events; passed to
+                                       the workers via the startup script (defaults to 60)
+--keepalive-startup-timeout SECONDS    How long to wait after an instance is started for its
+                                       first keep-alive event before considering it failed; if no
+                                       instance has ever sent a keep-alive and all instances
+                                       exceed this timeout, all instances are terminated and the
+                                       job is aborted; 0 disables the check (defaults to 600)
+--keepalive-timeout SECONDS            How long to wait after a keep-alive event for the next one
+                                       before declaring the instance crashed and terminating it;
+                                       0 disables the check (defaults to 300)
 
 
 .. _cli_information_commands:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -281,6 +281,12 @@ Options to specify the worker process and run process
   unhandled exception
 * ``retry_on_timeout``: If True, tasks will be retried if they exceed the maximum runtime
   specified by ``max_runtime``
+* ``max_memory_allowed_per_task``: The maximum memory in GB each task process is allowed
+  to use; this value is passed to the workers through the generated startup script and is
+  enforced by the operating system as an address-space limit on each task process. A task
+  that exceeds the limit fails with a ``MemoryError`` and is never retried (regardless of
+  ``retry_on_exception``). If not specified, there is no limit. See
+  :ref:`worker_memory_limit` for details and caveats.
 * ``keepalive_interval``: The interval in seconds between keep-alive events sent by each
   worker to the event queue; this value is passed to the workers through the generated
   startup script (if not specified, workers use their built-in default of 60 seconds)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -281,6 +281,21 @@ Options to specify the worker process and run process
   unhandled exception
 * ``retry_on_timeout``: If True, tasks will be retried if they exceed the maximum runtime
   specified by ``max_runtime``
+* ``keepalive_interval``: The interval in seconds between keep-alive events sent by each
+  worker to the event queue; this value is passed to the workers through the generated
+  startup script (if not specified, workers use their built-in default of 60 seconds)
+* ``keepalive_startup_timeout``: How long in seconds to wait after an instance is started
+  for its first keep-alive event (defaults to 600; 0 disables the check). If an instance
+  exceeds this timeout while other instances are sending keep-alives, the instance is
+  assumed to have failed to start and is terminated (a replacement will be created if
+  needed). If *no* instance has ever sent a keep-alive and every instance exceeds this
+  timeout, the startup script is assumed to be broken: all instances are terminated and
+  the job is aborted.
+* ``keepalive_timeout``: How long in seconds to wait after a keep-alive event for the next
+  one from the same instance (defaults to 300; 0 disables the check). An instance that
+  exceeds this timeout is assumed to have crashed and is terminated; a replacement will be
+  created if needed. This value should be set to several times the keep-alive interval so
+  that a single delayed event doesn't cause a healthy instance to be terminated.
 * ``db_file``: Path to the SQLite database file used by the ``run`` command to track task
   status and events (defaults to ``{job_id}.db`` in the current working directory). The 
   database enables crash recovery via the ``--continue`` option and stores comprehensive 

--- a/docs/example_parallel_addition.rst
+++ b/docs/example_parallel_addition.rst
@@ -390,6 +390,10 @@ If you want to save the raw events to a file in addition to the SQLite database,
 
   cloud_tasks run --config examples/parallel_addition/config.yml --task-file examples/parallel_addition/addition_tasks.json --output-file addition_events.log [other options...]
 
+If you interrupt the run and later resume it with ``--continue``, adding ``--output-file``
+at that point still gives you a complete log: because the file does not exist yet, the
+events already recorded in the database are written to it before monitoring resumes.
+
 
 Version 2: Addition with Exceptions and Timeouts
 ------------------------------------------------

--- a/docs/provider_gcp.rst
+++ b/docs/provider_gcp.rst
@@ -2,13 +2,21 @@ GCP-Specific Documentation
 ==========================
 
 
-Known Issues
-------------
+Queue Visibility Timeout
+------------------------
 
-- The maximum queue visibility timeout allowed by GCP Pub/Sub is 600 seconds. This means
-  that if your task takes longer than 600 seconds to complete, it will be retried even if
-  it's still in process on another worker. The only current workaround is to break your
-  task into smaller chunks so that none of them exceed 600 seconds.
+The maximum queue visibility timeout (ack deadline) allowed by GCP Pub/Sub is 600 seconds.
+Tasks are not limited to that duration, because the worker renews the visibility timeout of
+each running task roughly every half of that interval, extending it for as long as the task
+keeps running (up to ``--max-runtime``). A task that takes hours is therefore not redelivered
+to another worker while it is still making progress.
+
+If a worker dies, its renewals stop and the task becomes visible again within at most 600
+seconds, which is how a crashed worker's task gets picked up by someone else. The same
+mechanism means a worker that is alive but unable to reach Pub/Sub - for example during a
+network partition long enough for the deadline to lapse - can have its task redelivered and
+executed a second time. Tasks should be written to tolerate this; see
+:ref:`gcp_queues` for the delivery guarantees the queue types provide.
 
 
 Setup

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -309,7 +309,9 @@ This will perform the following steps:
 
        cloud_tasks run --config myconfig.yml --task-file my_tasks.json --output-file events.json
 
-   The events file will contain one JSON object per line for each event.
+   The events file will contain one JSON object per line for each event. The file is
+   appended to rather than overwritten, so it survives a resume with ``--continue``
+   (see :ref:`quickstart_crash_recovery`).
 
 #. When all tasks complete (or time out with no retry), automatically terminate instances
    and delete queues.
@@ -373,6 +375,13 @@ This will:
 #. Drain any pending events from the event queue to catch up on missed updates
 #. Query the cloud for current instance status
 #. Resume monitoring and managing instances until all tasks complete
+
+If you use ``--output-file`` with ``--continue`` and the file does not exist yet — because
+the earlier part of the job ran without ``--output-file``, or the file was moved away — the
+events already recorded in the database are written to it first, so you end up with a
+complete log of the whole job rather than only the part that ran after the resume. A file
+that already exists is appended to and never rewritten, so resuming repeatedly does not
+duplicate the history.
 
 .. note::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -309,9 +309,10 @@ This will perform the following steps:
 
        cloud_tasks run --config myconfig.yml --task-file my_tasks.json --output-file events.json
 
-   The events file will contain one JSON object per line for each event. The file is
-   appended to rather than overwritten, so it survives a resume with ``--continue``
-   (see :ref:`quickstart_crash_recovery`).
+   The events file will contain one JSON object per line for each task event. The file
+   is appended to rather than overwritten, so it survives a resume with ``--continue``
+   (see :ref:`quickstart_crash_recovery`). Worker keep-alive events are used only to
+   monitor instance health and are not written to the file or stored in the database.
 
 #. When all tasks complete (or time out with no retry), automatically terminate instances
    and delete queues.

--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -169,6 +169,7 @@ Optional Parameters
 --no-event-log-to-file                     If specified, events will not be written to a file [or ``RMS_CLOUD_TASKS_EVENT_LOG_TO_FILE`` is "0" or "false"]
 --event-log-to-queue                       If specified, events will be written to a cloud-based queue (default if --task-file is not specified) [or ``RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE`` is "1" or "true"]
 --no-event-log-to-queue                    If specified, events will not be written to a cloud-based queue [or ``RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE`` is "0" or "false"]
+--keepalive-interval SECONDS               Interval in seconds between keep-alive events sent to the cloud-based event queue so the task manager knows this instance is still alive; only used when events are being written to a cloud-based queue; 0 disables keep-alive events [or ``RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL``] (default 60 seconds)
 --instance-type INSTANCE_TYPE              Instance type; optional information for the worker processes [or ``RMS_CLOUD_TASKS_INSTANCE_TYPE``]
 --num-cpus N                               Number of vCPUs on this computer; optional information for the worker processes [or ``RMS_CLOUD_TASKS_INSTANCE_NUM_VCPUS``]
 --memory MEMORY_GB                         Memory in GB on this computer; optional information for the worker processes [or ``RMS_CLOUD_TASKS_INSTANCE_MEM_GB``]
@@ -266,6 +267,14 @@ The ``event_type`` field can have the following values:
   No further tasks will be accepted and any existing tasks may be terminated prematurely
   if the instance is destroyed before they finish. Any existing tasks that complete before
   the instance is destroyed will have their results reported as usual.
+- ``keep_alive``: Sent periodically (every ``--keepalive-interval`` seconds, 60 by default)
+  to indicate the worker is still alive, independent of the status of any tasks. The
+  ``instance_id`` field contains the instance ID as known to the cloud provider (obtained
+  from the provider's metadata server, falling back to the hostname). These events are only
+  sent to the cloud-based event queue, never to a local event log file, and the task
+  manager intercepts them (they are not printed or stored in the task database) to track
+  the health of each instance. Instances that never send a keep-alive or stop sending them
+  are terminated by the task manager (see :ref:`config_worker_and_manage_pool_options`).
 
 
 .. _worker_spot_instances:

--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -180,6 +180,7 @@ Optional Parameters
 --price PRICE_PER_HOUR                     Price in USD/hour on this computer; optional information for the worker processes [or ``RMS_CLOUD_TASKS_INSTANCE_PRICE``]
 --num-simultaneous-tasks N                 Number of concurrent tasks to process (defaults to number of vCPUs, or 1 if not specified) [or ``RMS_CLOUD_TASKS_NUM_TASKS_PER_INSTANCE``]
 --max-runtime SECONDS                      Maximum allowed runtime in seconds; used to determine queue visibility timeout and to kill tasks that are running too long [or ``RMS_CLOUD_TASKS_MAX_RUNTIME``] (default 600 seconds)
+--max-memory-allowed-per-task GB           Maximum memory in GB each task process is allowed to use, enforced by the OS as an address-space limit on the process; a task that exceeds it fails with a MemoryError and is not retried (see :ref:`worker_memory_limit`) [or ``RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK``] (default no limit)
 --shutdown-grace-period SECONDS            How long to wait in seconds for processes to gracefully finish after shutdown (SIGINT, SIGTERM, or Ctrl-C) is requested before killing them (default 30) [or ``RMS_CLOUD_TASKS_SHUTDOWN_GRACE_PERIOD``]
 --tasks-to-skip TASKS_TO_SKIP              Number of tasks to skip before processing any from the queue [or ``RMS_CLOUD_TASKS_TO_SKIP``]
 --max-num-tasks MAX_NUM_TASKS              Maximum number of tasks to process [or ``RMS_CLOUD_TASKS_MAX_NUM_TASKS``]
@@ -276,6 +277,34 @@ The ``event_type`` field can have the following values:
   the health of each instance. Instances that never send a keep-alive or stop sending them
   are terminated by the task manager (see :ref:`config_worker_and_manage_pool_options`).
 
+
+.. _worker_memory_limit:
+
+Limiting Task Memory Usage
+--------------------------
+
+The ``--max-memory-allowed-per-task`` option (or the
+``RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK`` environment variable) limits the amount of
+memory each task process may use. The limit is applied by the operating system (as an
+address-space limit, ``RLIMIT_AS``, set on each task process before the task starts), so no
+run-time monitoring is involved. When a task attempts to allocate memory beyond the limit,
+the allocation fails and Python raises a ``MemoryError``. The task then fails with a
+``task_exception`` event and is **never retried**, regardless of the ``--retry-on-exception``
+setting, because it would presumably just exceed the memory limit again.
+
+Notes and caveats:
+
+- The limit applies to *virtual address space*, not resident memory. Some software (GPU
+  runtimes, some memory allocators, programs that memory-map large files) reserves large
+  address ranges it never fully uses, so the limit should be set with some headroom above
+  the expected actual memory usage.
+- If the memory limit is exceeded inside non-Python code that does not handle allocation
+  failures gracefully, the process may crash instead of raising ``MemoryError``. In that
+  case the task is reported as ``task_exited`` and retry is governed by ``--retry-on-exit``.
+- If a task function spawns its own subprocesses, each one gets the same individual limit;
+  their combined usage is not limited.
+- The limit requires the POSIX ``resource`` module and is therefore not supported on
+  Windows, where it is ignored with a warning.
 
 .. _worker_spot_instances:
 

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -515,6 +515,27 @@ class EventMonitor:
         self.output_file = None
         self.something_changed = True
 
+    def _disable_output_file(self, reason: str) -> None:
+        """Stop writing to the output file after an I/O error.
+
+        The database is the authoritative record; a file that can no longer be written
+        must not be allowed to hold up event processing, so the stream is closed and
+        dropped and monitoring continues without it.
+
+        Parameters:
+            reason: What went wrong, for the log message.
+        """
+        logger.error(
+            f'No longer writing events to "{self.output_file_path}": {reason}. '
+            "Event processing continues; the database remains complete."
+        )
+        try:
+            if self.output_file is not None:
+                self.output_file.close()
+        except Exception:  # pragma: no cover - the stream is already broken
+            logger.debug("Error closing the events output file", exc_info=True)
+        self.output_file = None
+
     def _write_stored_events(self) -> int:
         """Write every event already in the database to the output file.
 
@@ -560,9 +581,11 @@ class EventMonitor:
                 try:
                     count = await asyncio.to_thread(self._write_stored_events)
                 except Exception as e:
-                    # The file is open and new events will still be written to it; a
-                    # partial history is better than aborting a job that is under way
-                    logger.error(f'Error writing stored events to "{path}": {e}', exc_info=True)
+                    # Don't abort a job that is already under way just because its log
+                    # file can't be written, but don't keep a stream that has already
+                    # failed either - writing to it again would stall event processing
+                    logger.debug(f'Error writing stored events to "{path}"', exc_info=True)
+                    self._disable_output_file(f"error writing stored events: {e}")
                 else:
                     if count:
                         logger.info(f'Wrote {count} events already in the database to "{path}"')
@@ -603,17 +626,22 @@ class EventMonitor:
 
                         self.something_changed = True
 
+                        # Update the database first: it is the authoritative record
+                        # and must not be skipped because of a problem with the
+                        # optional output file
+                        self.task_db.insert_event(data)
+                        self.task_db.update_task_from_event(data)
+
                         # Write to file if specified
                         if self.output_file:
-                            self.output_file.write(json.dumps(data) + "\n")
+                            try:
+                                self.output_file.write(json.dumps(data) + "\n")
+                            except Exception as e:
+                                self._disable_output_file(f"error writing event: {e}")
 
                         # Print to stdout if requested
                         if self.print_events:
                             print(json.dumps(data))
-
-                        # Update database
-                        self.task_db.insert_event(data)
-                        self.task_db.update_task_from_event(data)
 
                     except json.JSONDecodeError as e:
                         logger.error(f"Error decoding message: {e}")
@@ -621,7 +649,10 @@ class EventMonitor:
                         logger.error(f"Error processing message: {e}")
 
                 if self.output_file:
-                    self.output_file.flush()
+                    try:
+                        self.output_file.flush()
+                    except Exception as e:
+                        self._disable_output_file(f"error flushing events: {e}")
 
                 return len(messages)
             else:

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -2326,6 +2326,14 @@ def add_instance_pool_args(parser: argparse.ArgumentParser) -> None:
         help="Maximum seconds a single worker job is allowed to run (default: 3600)",
     )
     parser.add_argument(
+        "--max-memory-allowed-per-task",
+        type=float,
+        help="Maximum memory in GB each task process is allowed to use, enforced by the "
+        "OS as an address-space limit on the process; a task that exceeds it fails with "
+        "a MemoryError and is not retried; passed to workers via the startup script "
+        "(default: no limit)",
+    )
+    parser.add_argument(
         "--keepalive-interval",
         type=int,
         help="Interval in seconds between worker keep-alive events; passed to workers "

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -9,7 +9,7 @@ import logging
 import os
 import signal
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any, cast
 
@@ -483,6 +483,7 @@ class EventMonitor:
         *,
         print_events: bool = True,
         print_summary: bool = True,
+        keepalive_callback: Callable[[str, str | None], None] | None = None,
     ) -> None:
         """
         Initialize the event monitor.
@@ -493,12 +494,16 @@ class EventMonitor:
             output_file_path: Optional path to write events to
             print_events: Whether to print events to stdout
             print_summary: Whether to print summary statistics
+            keepalive_callback: Optional callback invoked with (instance_id, timestamp)
+                for each keep-alive event; keep-alive events are intercepted and never
+                printed, written to the output file, or stored in the database
         """
         self.events_queue = events_queue
         self.task_db = task_db
         self.output_file_path = output_file_path
         self.print_events = print_events
         self.print_summary = print_summary
+        self.keepalive_callback = keepalive_callback
         self.output_file = None
         self.something_changed = True
 
@@ -541,7 +546,6 @@ class EventMonitor:
             messages = await self.events_queue.receive_messages(max_count=100)
 
             if messages:
-                self.something_changed = True
                 for message in messages:
                     try:
                         payload = message.get("data", {})
@@ -553,6 +557,17 @@ class EventMonitor:
                             data = {}
                         if not isinstance(data, dict):
                             data = {}
+
+                        if data.get("event_type") == "keep_alive":
+                            # Keep-alive events are only used to track instance health;
+                            # they are not printed, written to a file, or stored in the
+                            # database
+                            instance_id = data.get("instance_id") or data.get("hostname")
+                            if instance_id and self.keepalive_callback:
+                                self.keepalive_callback(instance_id, data.get("timestamp"))
+                            continue
+
+                        self.something_changed = True
 
                         # Write to file if specified
                         if self.output_file:
@@ -1123,6 +1138,7 @@ async def run_cmd(args: argparse.Namespace, config: Config) -> None:
             output_file_path=getattr(args, "output_file", None),
             print_events=False,  # Don't print individual events
             print_summary=True,
+            keepalive_callback=orchestrator.record_keepalive,
         )
         await event_monitor.start()
 
@@ -1146,6 +1162,11 @@ async def run_cmd(args: argparse.Namespace, config: Config) -> None:
                 # Keep checking until job is complete or interrupted
                 while orchestrator.is_running and not job_complete and not interrupted:
                     await asyncio.sleep(1)
+                if orchestrator.keepalive_abort_reason is not None:
+                    # The orchestrator terminated all instances and aborted the job
+                    # because no worker ever sent a keep-alive event
+                    logger.error(f"Aborting job: {orchestrator.keepalive_abort_reason}")
+                    stop_signal.set()
             except Exception as e:
                 logger.error(f"Error in orchestrator: {e}", exc_info=True)
                 raise
@@ -1254,6 +1275,13 @@ async def run_cmd(args: argparse.Namespace, config: Config) -> None:
         finally:
             # Restore original signal handler
             signal.signal(signal.SIGINT, old_handler)
+
+        # If the orchestrator aborted the job (no worker ever sent a keep-alive event),
+        # the instances have already been terminated; report the failure and exit
+        if orchestrator.keepalive_abort_reason is not None:
+            logger.error(f"Job aborted: {orchestrator.keepalive_abort_reason}")
+            await orchestrator.stop(terminate_instances=False)
+            sys.exit(1)
 
         # If job completed normally, clean up
         if job_complete and not interrupted:
@@ -2296,6 +2324,26 @@ def add_instance_pool_args(parser: argparse.ArgumentParser) -> None:
         "--max-runtime",
         type=int,
         help="Maximum seconds a single worker job is allowed to run (default: 3600)",
+    )
+    parser.add_argument(
+        "--keepalive-interval",
+        type=int,
+        help="Interval in seconds between worker keep-alive events; passed to workers "
+        "via the startup script (default: 60)",
+    )
+    parser.add_argument(
+        "--keepalive-startup-timeout",
+        type=int,
+        help="Seconds to wait after an instance is started for its first keep-alive event "
+        "before considering it failed; if no instance has ever sent a keep-alive, all "
+        "instances are terminated and the job is aborted; 0 disables the check "
+        "(default: 600)",
+    )
+    parser.add_argument(
+        "--keepalive-timeout",
+        type=int,
+        help="Seconds to wait after a keep-alive event for the next one before declaring "
+        "the instance crashed and terminating it; 0 disables the check (default: 300)",
     )
     parser.add_argument(
         "--retry-on-exit",

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -484,6 +484,7 @@ class EventMonitor:
         print_events: bool = True,
         print_summary: bool = True,
         keepalive_callback: Callable[[str, str | None], None] | None = None,
+        backfill_output_file: bool = False,
     ) -> None:
         """
         Initialize the event monitor.
@@ -497,6 +498,12 @@ class EventMonitor:
             keepalive_callback: Optional callback invoked with (instance_id, timestamp)
                 for each keep-alive event; keep-alive events are intercepted and never
                 printed, written to the output file, or stored in the database
+            backfill_output_file: Whether to seed a newly created output file with the
+                events already recorded in the database. Used when attaching to a job
+                that is already under way so the file is a complete log of the job
+                rather than only the part observed by this process. Ignored when the
+                output file already exists, since those events are presumed to be in it
+                already.
         """
         self.events_queue = events_queue
         self.task_db = task_db
@@ -504,13 +511,30 @@ class EventMonitor:
         self.print_events = print_events
         self.print_summary = print_summary
         self.keepalive_callback = keepalive_callback
+        self.backfill_output_file = backfill_output_file
         self.output_file = None
         self.something_changed = True
+
+    def _write_stored_events(self) -> int:
+        """Write every event already in the database to the output file.
+
+        Returns:
+            The number of events written.
+        """
+        assert self.output_file is not None
+        count = 0
+        for raw_event in self.task_db.iter_raw_events():
+            self.output_file.write(raw_event.rstrip("\n") + "\n")
+            count += 1
+        self.output_file.flush()
+        return count
 
     async def start(self) -> None:
         """Start monitoring events."""
         if self.output_file_path:
             path = self.output_file_path
+            # Decide before opening, since opening for append creates the file
+            backfill = self.backfill_output_file and not Path(path).exists()
             try:
 
                 def _open_file(p: str, mode: str) -> Any:
@@ -532,6 +556,16 @@ class EventMonitor:
             except Exception as e:
                 logger.fatal(f'Error opening events file "{path}": {e}', exc_info=True)
                 sys.exit(1)
+            if backfill and self.output_file is not None:
+                try:
+                    count = await asyncio.to_thread(self._write_stored_events)
+                except Exception as e:
+                    # The file is open and new events will still be written to it; a
+                    # partial history is better than aborting a job that is under way
+                    logger.error(f'Error writing stored events to "{path}": {e}', exc_info=True)
+                else:
+                    if count:
+                        logger.info(f'Wrote {count} events already in the database to "{path}"')
         return
 
     async def process_events_batch(self) -> int:
@@ -725,6 +759,8 @@ async def monitor_event_queue_cmd(args: argparse.Namespace, config: Config) -> N
             output_file_path=getattr(args, "output_file", None),
             print_events=getattr(args, "print_events", False),
             print_summary=True,
+            # This command only ever attaches to a job that is already under way
+            backfill_output_file=True,
         )
         await event_monitor.start()
 
@@ -1139,6 +1175,8 @@ async def run_cmd(args: argparse.Namespace, config: Config) -> None:
             print_events=False,  # Don't print individual events
             print_summary=True,
             keepalive_callback=orchestrator.record_keepalive,
+            # A fresh run starts with an empty database, so there is nothing to seed
+            backfill_output_file=args.continue_run,
         )
         await event_monitor.start()
 

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -472,6 +472,14 @@ async def list_running_instances_cmd(args: argparse.Namespace, config: Config) -
         sys.exit(1)
 
 
+class _OutputFileError(Exception):
+    """Raised when writing to the events output file fails.
+
+    Distinguishes an unusable output file, which is optional and can be dropped, from a
+    failure to read the events being written, which says nothing about the file.
+    """
+
+
 class EventMonitor:
     """Helper class for monitoring events from the event queue and updating the database."""
 
@@ -541,13 +549,25 @@ class EventMonitor:
 
         Returns:
             The number of events written.
+
+        Raises:
+            _OutputFileError: If writing or flushing the output file fails.
+            Exception: Whatever reading the events from the database raises, so the
+                caller can tell an unusable output file apart from an unreadable
+                database.
         """
         assert self.output_file is not None
         count = 0
         for raw_event in self.task_db.iter_raw_events():
-            self.output_file.write(raw_event.rstrip("\n") + "\n")
+            try:
+                self.output_file.write(raw_event.rstrip("\n") + "\n")
+            except Exception as e:
+                raise _OutputFileError(f"error writing stored events: {e}") from e
             count += 1
-        self.output_file.flush()
+        try:
+            self.output_file.flush()
+        except Exception as e:
+            raise _OutputFileError(f"error flushing stored events: {e}") from e
         return count
 
     async def start(self) -> None:
@@ -580,12 +600,19 @@ class EventMonitor:
             if backfill and self.output_file is not None:
                 try:
                     count = await asyncio.to_thread(self._write_stored_events)
+                except _OutputFileError as e:
+                    # The file itself is unusable, so drop it; keeping a stream that has
+                    # already failed would only stall event processing later
+                    self._disable_output_file(str(e))
                 except Exception as e:
-                    # Don't abort a job that is already under way just because its log
-                    # file can't be written, but don't keep a stream that has already
-                    # failed either - writing to it again would stall event processing
-                    logger.debug(f'Error writing stored events to "{path}"', exc_info=True)
-                    self._disable_output_file(f"error writing stored events: {e}")
+                    # Reading the stored events failed, which says nothing about the
+                    # output file - keep it and log the live events from here on. Either
+                    # way, don't abort a job that is already under way
+                    logger.error(
+                        f'Error reading stored events from the database, so "{path}" will '
+                        f"cover only the events received from now on: {e}",
+                        exc_info=True,
+                    )
                 else:
                     if count:
                         logger.info(f'Wrote {count} events already in the database to "{path}"')

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -2249,7 +2249,7 @@ def add_common_args(
         "-v",
         action="count",
         default=0,
-        help="Increase verbosity level (-v for warning, -vv for info, -vvv for debug)",
+        help="Increase verbosity level (default is warning, -v for info, -vv or more for debug)",
     )
 
 

--- a/src/cloud_tasks/common/config.py
+++ b/src/cloud_tasks/common/config.py
@@ -224,6 +224,20 @@ class RunConfig(BaseModel, validate_assignment=True):
     retry_on_timeout: bool | None = None
 
     #
+    # Worker keep-alive options
+    #
+
+    # Interval in seconds between worker keep-alive events (passed to workers via the
+    # startup script); if None, workers use their own default (60 seconds)
+    keepalive_interval: PositiveInt | None = None
+    # Seconds to wait after an instance is started for its first keep-alive event;
+    # 0 disables the check (default 600 seconds)
+    keepalive_startup_timeout: NonNegativeInt | None = None
+    # Seconds to wait after a keep-alive event for the next one before declaring the
+    # instance dead; 0 disables the check (default 300 seconds)
+    keepalive_timeout: NonNegativeInt | None = None
+
+    #
     # Database options
     #
     db_file: str | None = None  # SQLite database file path

--- a/src/cloud_tasks/common/config.py
+++ b/src/cloud_tasks/common/config.py
@@ -222,6 +222,10 @@ class RunConfig(BaseModel, validate_assignment=True):
     retry_on_exit: bool | None = None
     retry_on_exception: bool | None = None
     retry_on_timeout: bool | None = None
+    # Maximum memory in GB each task process may use, enforced by the OS as an
+    # address-space limit; a task that exceeds it fails with a MemoryError and is not
+    # retried (passed to workers via the startup script); if None, there is no limit
+    max_memory_allowed_per_task: PositiveFloat | None = None
 
     #
     # Worker keep-alive options

--- a/src/cloud_tasks/common/task_db.py
+++ b/src/cloud_tasks/common/task_db.py
@@ -5,6 +5,7 @@ SQLite database for task tracking and event logging.
 import json
 import logging
 import sqlite3
+from collections.abc import Iterator
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -252,6 +253,28 @@ class TaskDatabase:
             ),
         )
         conn.commit()
+
+    def iter_raw_events(self) -> Iterator[str]:
+        """Yield the raw JSON of every stored event, oldest first.
+
+        Events are streamed rather than returned as a list because a long job can
+        accumulate tens of thousands of them.
+
+        Yields:
+            The raw_event JSON string of each event, in the order it was recorded.
+        """
+        conn = self._get_conn()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT raw_event
+            FROM events
+            ORDER BY id
+            """
+        )
+        for row in cursor:
+            if row["raw_event"] is not None:
+                yield str(row["raw_event"])
 
     def get_task_counts(self) -> dict[str, int]:
         """

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -716,6 +716,126 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
             return boot_disk_types_cfg
         return self._DEFAULT_BOOT_DISK_TYPE
 
+    def _keepalive_monitoring_active(self) -> bool:
+        """Whether the keep-alive monitor is (about to be) running for this orchestrator.
+
+        False when the orchestrator isn't running the job itself - e.g. the ``status``
+        command, which builds an orchestrator just to query instances and so never
+        receives keep-alive events - so the instance table doesn't report healthy
+        workers as silent.
+        """
+        return (
+            self._running
+            and not self._dry_run
+            and (self._keepalive_startup_timeout > 0 or self._keepalive_timeout > 0)
+        )
+
+    def _keepalive_status(self, instance: dict[str, Any], now: float) -> tuple[str, str]:
+        """Describe an instance's keep-alive state for the debug instance table.
+
+        Parameters:
+            instance: Instance dictionary from list_job_instances
+            now: Current time (time.time()), passed in so every row of a table is
+                described relative to the same instant
+
+        Returns:
+            tuple[str, str]: (last keep-alive column, status column)
+        """
+        if instance["state"] not in ("running", "starting"):
+            return "-", "not active"
+        if not self._keepalive_monitoring_active():
+            return "-", "not monitored"
+
+        instance_id = instance["id"]
+        last_heard = self._keepalive_last_heard.get(instance_id)
+
+        if last_heard is not None:
+            silent_for = now - last_heard
+            last_str = f"{silent_for:.0f}s ago"
+            if self._keepalive_timeout <= 0:
+                return last_str, "OK (timeout disabled)"
+            if silent_for > self._keepalive_timeout:
+                return last_str, (
+                    f"OVERDUE by {silent_for - self._keepalive_timeout:.0f}s "
+                    f"(limit {self._keepalive_timeout:.0f}s)"
+                )
+            return last_str, f"OK ({self._keepalive_timeout - silent_for:.0f}s until overdue)"
+
+        first_seen = self._keepalive_first_seen.get(instance_id)
+        if first_seen is None:
+            # The keep-alive monitor hasn't seen this instance yet; it will start its
+            # startup clock on its next pass
+            return "never", "awaiting first keep-alive"
+        waiting_for = now - first_seen
+        if self._keepalive_startup_timeout <= 0:
+            return "never", f"awaiting first keep-alive ({waiting_for:.0f}s, timeout disabled)"
+        if waiting_for > self._keepalive_startup_timeout:
+            return "never", (
+                f"OVERDUE by {waiting_for - self._keepalive_startup_timeout:.0f}s for its first "
+                f"keep-alive (limit {self._keepalive_startup_timeout:.0f}s)"
+            )
+        return "never", (
+            f"awaiting first keep-alive ({waiting_for:.0f}s of "
+            f"{self._keepalive_startup_timeout:.0f}s)"
+        )
+
+    def _log_instance_details(self, instances: list[dict[str, Any]]) -> None:
+        """Log a table with one row per instance, including its keep-alive status.
+
+        This is a diagnostic aid that adds a line of output per instance every time the
+        instance summary is computed, so it is only emitted when debug logging is
+        enabled (-vv or higher).
+
+        Parameters:
+            instances: Instance dictionaries from list_job_instances
+        """
+        if not self._logger.isEnabledFor(logging.DEBUG):
+            return
+
+        if not instances:
+            self._logger.debug("Instance details: no instances")
+            return
+
+        now = time.time()
+        headers = ["Instance ID", "Type", "State", "Zone", "Created", "Keep-Alive", "Status"]
+        rows = []
+        for instance in sorted(instances, key=lambda i: str(i["id"])):
+            # Azure instances don't report a zone, creation time, or boot disk type
+            created = str(instance.get("creation_time") or "-")[:19]
+            zone = str(instance.get("zone") or instance.get("location") or "-")
+            last_keepalive, status = self._keepalive_status(instance, now)
+            rows.append(
+                [
+                    str(instance["id"]),
+                    str(instance["type"]),
+                    str(instance["state"]),
+                    zone,
+                    created,
+                    last_keepalive,
+                    status,
+                ]
+            )
+
+        # Size each column to its widest value, since instance IDs, types, and zones
+        # vary a lot in length between providers. The final column isn't padded because
+        # nothing follows it.
+        widths = [
+            max(len(header), *(len(row[col]) for row in rows))
+            for col, header in enumerate(headers[:-1])
+        ]
+
+        def format_row(cells: list[str]) -> str:
+            padded = [cell.ljust(width) for cell, width in zip(cells, widths)]
+            return "  " + "  ".join([*padded, cells[-1]])
+
+        table = [format_row(headers), *(format_row(row) for row in rows)]
+        separator = "  " + "-" * (max(len(line) for line in table) - 2)
+        self._logger.debug("Instance details:")
+        self._logger.debug(table[0])
+        self._logger.debug(separator)
+        for line in table[1:]:
+            self._logger.debug(line)
+
     async def get_job_instances(self) -> tuple[int, int, float, str]:
         """Return job instance counts and pricing summary.
 
@@ -737,6 +857,8 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
             self._logger.error(f"Failed to get running instances: {e}", exc_info=True)
             self._logger.error("Cannot make scaling decisions without instance information")
             return 0, 0, 0.0, "Error getting running instances"
+
+        self._log_instance_details(running_instances)
 
         # Count the number of instances of each type and running status
         # Also count by "state" and "zone" fields

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -249,6 +249,12 @@ class InstanceOrchestrator:
             f"  Instance termination delay: {self._instance_termination_delay} seconds"
         )
         self._logger.info(f"  Max runtime: {self._run_config.max_runtime} seconds")
+        if self._run_config.max_memory_allowed_per_task is not None:
+            self._logger.info(
+                f"  Max memory allowed per task: {self._run_config.max_memory_allowed_per_task} GB"
+            )
+        else:
+            self._logger.info("  Max memory allowed per task: No limit")
         if self._run_config.keepalive_interval is not None:
             self._logger.info(
                 f"  Worker keep-alive interval: {self._run_config.keepalive_interval} seconds"
@@ -332,6 +338,12 @@ export RMS_CLOUD_TASKS_PROJECT_ID={project_id}
 export RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL={self._run_config.keepalive_interval}
 """
 
+        max_memory_supplement = ""
+        if self._run_config.max_memory_allowed_per_task is not None:
+            max_memory_supplement = f"""\
+export RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK={self._run_config.max_memory_allowed_per_task}
+"""
+
         oii = self._optimal_instance_info
         supplement = f"""\
 export RMS_CLOUD_TASKS_PROVIDER={self._provider}
@@ -350,7 +362,7 @@ export RMS_CLOUD_TASKS_NUM_TASKS_PER_INSTANCE={self._optimal_instance_num_tasks}
 export RMS_CLOUD_TASKS_MAX_RUNTIME={self._run_config.max_runtime}
 export RMS_CLOUD_TASKS_RETRY_ON_EXIT={self._run_config.retry_on_exit}
 export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
-{keepalive_supplement}"""
+{keepalive_supplement}{max_memory_supplement}"""
         if not self._run_config.startup_script:
             raise RuntimeError("No startup script provided")
 

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -51,6 +51,12 @@ class InstanceOrchestrator:
     _DEFAULT_BOOT_DISK_TYPE = "pd-balanced"
     # Sentinel for max_allowed_instances when --max-instances is not set (no limit).
     _MAX_ALLOWED_INSTANCES_SENTINEL = 999999
+    # How long to wait after an instance is started for its first keep-alive event
+    _DEFAULT_KEEPALIVE_STARTUP_TIMEOUT = 600.0
+    # How long to wait after a keep-alive event for the next one
+    _DEFAULT_KEEPALIVE_TIMEOUT = 300.0
+    # How often to check for overdue keep-alive events
+    _KEEPALIVE_CHECK_INTERVAL = 15.0
 
     def __init__(
         self,
@@ -121,6 +127,29 @@ class InstanceOrchestrator:
         self._empty_queue_since = None
         self._instance_termination_delay = self._run_config.instance_termination_delay
         self._scaling_task: asyncio.Task[None] | None = None
+
+        # Keep-alive tracking for detecting failed or crashed instances
+        startup_timeout = self._run_config.keepalive_startup_timeout
+        self._keepalive_startup_timeout: float = (
+            float(startup_timeout)
+            if startup_timeout is not None
+            else self._DEFAULT_KEEPALIVE_STARTUP_TIMEOUT
+        )
+        keepalive_timeout = self._run_config.keepalive_timeout
+        self._keepalive_timeout: float = (
+            float(keepalive_timeout)
+            if keepalive_timeout is not None
+            else self._DEFAULT_KEEPALIVE_TIMEOUT
+        )
+        # Maps instance ID to the time we last received a keep-alive event from it
+        self._keepalive_last_heard: dict[str, float] = {}
+        # Maps instance ID to the time we first saw it in the running instance list
+        self._keepalive_first_seen: dict[str, float] = {}
+        # Whether any instance has ever sent a keep-alive event
+        self._keepalive_ever_heard = False
+        self._keepalive_task: asyncio.Task[None] | None = None
+        # Set when keep-alive monitoring determined no instance ever started properly
+        self._keepalive_abort_reason: str | None = None
 
         # Initialize lock for instance creation
         self._instance_creation_lock = asyncio.Lock()
@@ -220,6 +249,21 @@ class InstanceOrchestrator:
             f"  Instance termination delay: {self._instance_termination_delay} seconds"
         )
         self._logger.info(f"  Max runtime: {self._run_config.max_runtime} seconds")
+        if self._run_config.keepalive_interval is not None:
+            self._logger.info(
+                f"  Worker keep-alive interval: {self._run_config.keepalive_interval} seconds"
+            )
+        else:
+            self._logger.info("  Worker keep-alive interval: worker default (60 seconds)")
+        self._logger.info(
+            "  Keep-alive startup timeout: "
+            f"{self._keepalive_startup_timeout} seconds"
+            f"{' (disabled)' if self._keepalive_startup_timeout == 0 else ''}"
+        )
+        self._logger.info(
+            f"  Keep-alive timeout: {self._keepalive_timeout} seconds"
+            f"{' (disabled)' if self._keepalive_timeout == 0 else ''}"
+        )
         self._logger.info(f"  Max parallel instance creations: {self._start_instance_max_threads}")
         self._logger.info(f"  Image: {self._run_config.image}")
         self._logger.info("  Startup script:")
@@ -241,6 +285,27 @@ class InstanceOrchestrator:
     def queue_name(self) -> str:
         return self._queue_name
 
+    @property
+    def keepalive_abort_reason(self) -> str | None:
+        """Reason the job was aborted by keep-alive monitoring, or None."""
+        return self._keepalive_abort_reason
+
+    def record_keepalive(self, instance_id: str, timestamp: str | None = None) -> None:
+        """Record a keep-alive event received from a worker instance.
+
+        Parameters:
+            instance_id: The ID of the instance the keep-alive came from, as reported
+                by the instance manager (GCP/Azure: instance name; AWS: instance ID).
+            timestamp: The time the keep-alive was sent, as reported by the worker
+                (informational only; the local receive time is used for timeouts so
+                clock skew between machines doesn't matter).
+        """
+        if instance_id not in self._keepalive_last_heard:
+            self._logger.info(f"Received first keep-alive event from instance '{instance_id}'")
+        self._logger.debug(f"Keep-alive from instance '{instance_id}' (sent at {timestamp})")
+        self._keepalive_last_heard[instance_id] = time.time()
+        self._keepalive_ever_heard = True
+
     def _generate_worker_startup_script(self) -> str:
         """
         Generate a startup script for worker instances.
@@ -261,6 +326,12 @@ export RMS_CLOUD_TASKS_PROJECT_ID={project_id}
             raise RuntimeError("_optimal_instance_boot_disk_size is not set")
         if self._optimal_instance_num_tasks is None:
             raise RuntimeError("_optimal_instance_num_tasks is not set")
+        keepalive_supplement = ""
+        if self._run_config.keepalive_interval is not None:
+            keepalive_supplement = f"""\
+export RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL={self._run_config.keepalive_interval}
+"""
+
         oii = self._optimal_instance_info
         supplement = f"""\
 export RMS_CLOUD_TASKS_PROVIDER={self._provider}
@@ -279,7 +350,7 @@ export RMS_CLOUD_TASKS_NUM_TASKS_PER_INSTANCE={self._optimal_instance_num_tasks}
 export RMS_CLOUD_TASKS_MAX_RUNTIME={self._run_config.max_runtime}
 export RMS_CLOUD_TASKS_RETRY_ON_EXIT={self._run_config.retry_on_exit}
 export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
-"""
+{keepalive_supplement}"""
         if not self._run_config.startup_script:
             raise RuntimeError("No startup script provided")
 
@@ -457,6 +528,8 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
             self._running = False
         else:
             self._scaling_task = asyncio.create_task(self._scaling_loop())
+            if self._keepalive_startup_timeout > 0 or self._keepalive_timeout > 0:
+                self._keepalive_task = asyncio.create_task(self._keepalive_monitor_loop())
 
     async def _scaling_loop(self) -> None:
         """Background task to periodically check scaling."""
@@ -477,6 +550,142 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
             # Handle task cancellation gracefully
             self._logger.info("Scaling loop cancelled")
             raise  # Re-raise to properly handle cancellation
+
+    async def _keepalive_monitor_loop(self) -> None:
+        """Background task to periodically check for overdue keep-alive events."""
+        last_check = time.time()
+        try:
+            while self._running:
+                try:
+                    now = time.time()
+                    if now - last_check > self._KEEPALIVE_CHECK_INTERVAL:
+                        await self._check_keepalives()
+                        last_check = now
+                except Exception as e:
+                    self._logger.error(f"Error in keep-alive monitor loop: {e}", exc_info=True)
+
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            self._logger.info("Keep-alive monitor loop cancelled")
+            raise
+
+    async def _check_keepalives(self) -> None:
+        """Check all job instances for overdue keep-alive events.
+
+        Two timeouts are enforced:
+
+        - keepalive_startup_timeout: How long after an instance is first seen we wait
+          for its first keep-alive event. If it is exceeded and no instance has ever
+          sent a keep-alive, and every active instance is overdue, the startup script
+          is assumed to be broken: all instances are terminated and the job is aborted
+          (keepalive_abort_reason is set). If other instances are alive, only the
+          overdue instance is terminated.
+        - keepalive_timeout: How long after the most recent keep-alive event from an
+          instance we wait for the next one. If it is exceeded the instance is assumed
+          to have crashed and is terminated; the scaling loop will start a replacement
+          if one is needed.
+        """
+        now = time.time()
+
+        instances = await self.list_job_instances()
+        active = {
+            instance["id"]: instance
+            for instance in instances
+            if instance["state"] in ("running", "starting")
+        }
+
+        # Drop tracking for instances that no longer exist (terminated by us, by the
+        # scaling loop, or externally)
+        for instance_id in list(self._keepalive_first_seen):
+            if instance_id not in active:
+                del self._keepalive_first_seen[instance_id]
+        for instance_id in list(self._keepalive_last_heard):
+            if instance_id not in active:
+                del self._keepalive_last_heard[instance_id]
+
+        startup_overdue = []
+        for instance_id, instance in active.items():
+            if instance_id not in self._keepalive_first_seen:
+                self._keepalive_first_seen[instance_id] = now
+
+            last_heard = self._keepalive_last_heard.get(instance_id)
+            if last_heard is None:
+                silent_for = now - self._keepalive_first_seen[instance_id]
+                if self._keepalive_startup_timeout > 0 and silent_for > (
+                    self._keepalive_startup_timeout
+                ):
+                    startup_overdue.append((instance, silent_for))
+            else:
+                silent_for = now - last_heard
+                if self._keepalive_timeout > 0 and silent_for > self._keepalive_timeout:
+                    self._logger.warning(
+                        f"Instance '{instance_id}' has not sent a keep-alive event in "
+                        f"{silent_for:.0f} seconds (limit {self._keepalive_timeout:.0f}); "
+                        "assuming it has crashed and terminating it"
+                    )
+                    await self._terminate_keepalive_instance(instance)
+
+        if not startup_overdue:
+            return
+
+        if self._keepalive_ever_heard:
+            # Other instances have started successfully, so the startup script works;
+            # only these specific instances failed. Terminate them and let the scaling
+            # loop start replacements if needed.
+            for instance, silent_for in startup_overdue:
+                self._logger.warning(
+                    f"Instance '{instance['id']}' has not sent its first keep-alive event "
+                    f"{silent_for:.0f} seconds after starting "
+                    f"(limit {self._keepalive_startup_timeout:.0f}); "
+                    "assuming it failed to start and terminating it"
+                )
+                await self._terminate_keepalive_instance(instance)
+            return
+
+        # No instance has ever sent a keep-alive event
+        if len(startup_overdue) == len(active):
+            # Every instance failed to start; the startup script is probably broken.
+            # Terminate everything and abort the job.
+            self._keepalive_abort_reason = (
+                f"No keep-alive event was received from any of the {len(active)} "
+                f"instance(s) within {self._keepalive_startup_timeout:.0f} seconds of "
+                "startup; the startup script is probably broken"
+            )
+            self._logger.error(self._keepalive_abort_reason)
+            self._logger.error("Terminating all instances and aborting the job")
+            await self.terminate_all_instances()
+            self._running = False
+        else:
+            # Some instances are still within their startup window. Don't terminate
+            # anything yet: if the startup script is broken, replacements would fail
+            # too, so wait until every instance is overdue and then abort above.
+            self._logger.warning(
+                f"{len(startup_overdue)} of {len(active)} instance(s) have not sent their "
+                "first keep-alive event within "
+                f"{self._keepalive_startup_timeout:.0f} seconds and no instance has ever "
+                "sent one; waiting for the remaining instances before deciding whether "
+                "to abort the job"
+            )
+
+    async def _terminate_keepalive_instance(self, instance: dict[str, Any]) -> None:
+        """Terminate an instance that failed its keep-alive checks.
+
+        Parameters:
+            instance: Instance dictionary from list_job_instances
+        """
+        instance_id = instance["id"]
+        if self._instance_manager is None:
+            raise RuntimeError("Instance manager not initialized. Call start() first.")
+        try:
+            await self._instance_manager.terminate_instance(instance_id, instance.get("zone"))
+            self._logger.info(f"Terminated unresponsive instance '{instance_id}'")
+        except Exception as e:
+            self._logger.error(
+                f"Failed to terminate unresponsive instance '{instance_id}': {e}", exc_info=True
+            )
+            return
+        self._keepalive_first_seen.pop(instance_id, None)
+        self._keepalive_last_heard.pop(instance_id, None)
 
     def _get_default_boot_disk_type(self) -> str:
         """
@@ -875,6 +1084,14 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
             self._scaling_task.cancel()
             try:
                 await self._scaling_task
+            except asyncio.CancelledError:
+                pass
+
+        # Cancel keep-alive monitor task if it exists
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
             except asyncio.CancelledError:
                 pass
 

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -55,8 +55,10 @@ class InstanceOrchestrator:
     _DEFAULT_KEEPALIVE_STARTUP_TIMEOUT = 600.0
     # How long to wait after a keep-alive event for the next one
     _DEFAULT_KEEPALIVE_TIMEOUT = 300.0
-    # How often to check for overdue keep-alive events
-    _KEEPALIVE_CHECK_INTERVAL = 15.0
+    # How often to check for overdue keep-alive events; each check lists the job's
+    # instances, so this is kept coarse (the timeouts are minutes) to limit the extra
+    # provider API load on top of the scaling loop's own instance listing
+    _KEEPALIVE_CHECK_INTERVAL = 60.0
 
     def __init__(
         self,
@@ -1219,7 +1221,9 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
                         return False
 
             current_instances = await self.list_job_instances()
-            running_instances = [i for i in current_instances if i["state"] == "running"]
+            running_instances = [
+                i for i in current_instances if i["state"] in ("running", "starting")
+            ]
 
             # Create tasks for all instance terminations
             tasks = [terminate_single_instance(instance) for instance in running_instances]

--- a/src/cloud_tasks/queue_manager/gcp.py
+++ b/src/cloud_tasks/queue_manager/gcp.py
@@ -29,8 +29,8 @@ class GCPPubSubQueue(QueueManager):
     # A message not acknowledged within this time will be made available again for processing
     _DEFAULT_VISIBILITY_TIMEOUT = 60
 
-    # Maximum visibility timeout allowed by GCP
-    _MAXIMUM_VISIBILITY_TIMEOUT = 30
+    # Maximum visibility timeout (ack deadline) allowed by GCP
+    _MAXIMUM_VISIBILITY_TIMEOUT = 600
 
     # Maximum number of messages that can be received at once allowed by GCP
     _MAXIMUM_MESSAGE_RECEIVE_COUNT = 1000
@@ -814,6 +814,10 @@ class GCPPubSubQueue(QueueManager):
         if timeout is None:
             # Use the current visibility timeout setting
             timeout = self._visibility_timeout or self._DEFAULT_VISIBILITY_TIMEOUT
+
+        # Clip to the maximum ack deadline GCP will accept; larger values are
+        # rejected with InvalidArgument
+        timeout = min(timeout, self._MAXIMUM_VISIBILITY_TIMEOUT)
 
         if self._exactly_once:
             # For exactly-once delivery, modify the ack deadline

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -1596,7 +1596,12 @@ class Worker:
                         f"{self._data.max_runtime} seconds (actual runtime {runtime:.1f} seconds); "
                         "terminating"
                     )
-                    await self._log_task_timed_out(task["task_id"], retry=False, runtime=runtime)
+                    # The retry flag must match what happens to the message below, or
+                    # the task database marks the task terminally timed out while the
+                    # message goes back on the queue for another attempt
+                    await self._log_task_timed_out(
+                        task["task_id"], retry=self._data.retry_on_timeout, runtime=runtime
+                    )
 
                     # Kill the process that exceeded runtime
                     try:

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -969,10 +969,13 @@ class Worker:
 
     async def _log_keep_alive(self) -> None:
         """Log a keep-alive event to the cloud-based event queue only."""
+        # The metadata server lookup uses synchronous HTTP calls, so run it in a
+        # thread to avoid blocking the event loop
+        instance_id = await asyncio.to_thread(self._get_instance_identity)
         await self._log_event(
             {
                 "event_type": self._EVENT_TYPE_KEEP_ALIVE,
-                "instance_id": self._get_instance_identity(),
+                "instance_id": instance_id,
             },
             queue_only=True,
         )
@@ -984,7 +987,8 @@ class Worker:
         instance ID reported by the instance managers (GCP/Azure: instance name;
         AWS: instance ID like "i-0abc..."). Falls back to the hostname if the
         metadata server is unavailable (e.g. when not running on a cloud instance).
-        The result is cached after the first call.
+        Only a metadata-server result is cached; the hostname fallback is re-tried
+        on the next call in case the failure was transient.
 
         Returns:
             The instance ID, or the hostname if the metadata server can't be reached.
@@ -1032,16 +1036,21 @@ class Worker:
                 )
                 if response.status_code == 200:
                     identity = response.text.strip()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Error querying the metadata server for the instance ID: {e}")
 
-        if not identity:
-            logger.debug("Could not determine instance ID from metadata server; using hostname")
-            identity = self._hostname
+        if identity:
+            self._instance_identity = identity
+            logger.info(f"Instance identity for keep-alive events: {identity}")
+            return identity
 
-        self._instance_identity = identity
-        logger.info(f"Instance identity for keep-alive events: {identity}")
-        return identity
+        # Don't cache the fallback: if the metadata server failure was transient, a
+        # permanently cached hostname would make the task manager believe this instance
+        # never started (on AWS the hostname doesn't match the instance ID) and
+        # terminate it even though it is healthy. Keep-alives are infrequent, so
+        # re-trying the lookup on each one is cheap.
+        logger.debug("Could not determine instance ID from metadata server; using hostname")
+        return self._hostname
 
     async def _keepalive_worker(self) -> None:
         """Background worker that periodically sends keep-alive events.

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -130,6 +130,14 @@ def _parse_args(
         "[overrides $RMS_CLOUD_TASKS_EVENT_LOG_TO_QUEUE]",
     )
     parser.add_argument(
+        "--keepalive-interval",
+        type=float,
+        help="Interval in seconds between keep-alive events sent to the cloud-based event "
+        "queue so the task manager knows this instance is still alive; 0 disables "
+        "keep-alive events [overrides $RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL] "
+        "(default 60 seconds)",
+    )
+    parser.add_argument(
         "--instance-type",
         help="Instance type; optional information for the worker processes "
         "[overrides $RMS_CLOUD_TASKS_INSTANCE_TYPE]",
@@ -395,6 +403,8 @@ class WorkerData:
         self.event_log_queue_name: str | None = None
         self.event_log_to_file: bool = False  #: Whether to log events to a file
         self.event_log_file: str | None = None  #: The name of the file to log events to
+        #: The interval in seconds between keep-alive events (0 disables them)
+        self.keepalive_interval: float = 60.0
         self.instance_type: str | None = None  #: The instance type this task is running on
         self.num_cpus: int | None = None  #: The number of vCPUs on this computer
         self.memory_gb: float | None = None  #: The amount of memory on this computer
@@ -609,6 +619,15 @@ class Worker:
                 logger.error("--event-log-to-queue requires either --job-id or --queue-name")
                 sys.exit(1)
 
+        # Get keep-alive interval from args or environment variable
+        raw_keepalive = parsed_args.keepalive_interval
+        if raw_keepalive is None:
+            env_val = os.getenv("RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL")
+            raw_keepalive = float(env_val) if env_val is not None else None
+        if raw_keepalive is not None:
+            self._data.keepalive_interval = float(raw_keepalive)
+        logger.info(f"  Keep-alive interval: {self._data.keepalive_interval} seconds")
+
         # Get instance type from args or environment variable
         self._data.instance_type = parsed_args.instance_type or os.getenv(
             "RMS_CLOUD_TASKS_INSTANCE_TYPE"
@@ -778,6 +797,7 @@ class Worker:
         signal.signal(signal.SIGTERM, self._signal_handler)
 
         self._hostname = socket.gethostname()
+        self._instance_identity: str | None = None
         self._event_logger_fp: IO[Any] | None = None
         self._event_logger_queue: QueueManager | None = None
 
@@ -820,9 +840,16 @@ class Worker:
     _EVENT_TYPE_NON_FATAL_EXCEPTION = "non_fatal_exception"
     _EVENT_TYPE_FATAL_EXCEPTION = "fatal_exception"
     _EVENT_TYPE_SPOT_TERMINATION = "spot_termination"
+    _EVENT_TYPE_KEEP_ALIVE = "keep_alive"
 
-    async def _log_event(self, event: dict[str, Any]) -> None:
-        """Log an event to the event log."""
+    async def _log_event(self, event: dict[str, Any], *, queue_only: bool = False) -> None:
+        """Log an event to the event log.
+
+        Args:
+            event: The event to log; must contain an "event_type" key.
+            queue_only: If True, only send the event to the cloud-based event queue,
+                never to the local event log file.
+        """
         # Reorder so these fields are first in the diction to make the display nicer
         new_event = {
             "timestamp": utc_now_iso(),
@@ -830,7 +857,7 @@ class Worker:
             "event_type": event["event_type"],
             **event,
         }
-        if self._event_logger_fp:
+        if self._event_logger_fp and not queue_only:
             self._event_logger_fp.write(json.dumps(new_event) + "\n")
             self._event_logger_fp.flush()
         if self._event_logger_queue:
@@ -910,6 +937,105 @@ class Worker:
     async def _log_spot_termination(self) -> None:
         """Log a spot termination event."""
         await self._log_event({"event_type": self._EVENT_TYPE_SPOT_TERMINATION})
+
+    async def _log_keep_alive(self) -> None:
+        """Log a keep-alive event to the cloud-based event queue only."""
+        await self._log_event(
+            {
+                "event_type": self._EVENT_TYPE_KEEP_ALIVE,
+                "instance_id": self._get_instance_identity(),
+            },
+            queue_only=True,
+        )
+
+    def _get_instance_identity(self) -> str:
+        """Get the instance ID as known to the cloud provider.
+
+        Queries the provider's metadata server so the returned value matches the
+        instance ID reported by the instance managers (GCP/Azure: instance name;
+        AWS: instance ID like "i-0abc..."). Falls back to the hostname if the
+        metadata server is unavailable (e.g. when not running on a cloud instance).
+        The result is cached after the first call.
+
+        Returns:
+            The instance ID, or the hostname if the metadata server can't be reached.
+        """
+        if self._instance_identity is not None:
+            return self._instance_identity
+
+        identity: str | None = None
+        try:
+            if self._data.provider == "AWS":
+                headers = {}
+                try:
+                    token_response = requests.put(
+                        "http://169.254.169.254/latest/api/token",
+                        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+                        timeout=2,
+                    )
+                    if token_response.status_code == 200:
+                        headers = {"X-aws-ec2-metadata-token": token_response.text}
+                except Exception:
+                    pass  # Fall back to IMDSv1
+                response = requests.get(
+                    "http://169.254.169.254/latest/meta-data/instance-id",
+                    headers=headers,
+                    timeout=2,
+                )
+                if response.status_code == 200:
+                    identity = response.text.strip()
+
+            elif self._data.provider == "GCP":
+                response = requests.get(
+                    "http://metadata.google.internal/computeMetadata/v1/instance/name",
+                    headers={"Metadata-Flavor": "Google"},
+                    timeout=2,
+                )
+                if response.status_code == 200:
+                    identity = response.text.strip()
+
+            elif self._data.provider == "AZURE":
+                response = requests.get(
+                    "http://169.254.169.254/metadata/instance/compute/name",
+                    params={"api-version": "2021-02-01", "format": "text"},
+                    headers={"Metadata": "true"},
+                    timeout=2,
+                )
+                if response.status_code == 200:
+                    identity = response.text.strip()
+        except Exception:
+            pass
+
+        if not identity:
+            logger.debug("Could not determine instance ID from metadata server; using hostname")
+            identity = self._hostname
+
+        self._instance_identity = identity
+        logger.info(f"Instance identity for keep-alive events: {identity}")
+        return identity
+
+    async def _keepalive_worker(self) -> None:
+        """Background worker that periodically sends keep-alive events.
+
+        The events are sent to the cloud-based event queue only (never to a local
+        event log file) so the task manager can detect instances that failed to
+        start or have crashed.
+        """
+        interval = self._data.keepalive_interval
+        logger.info(f"Starting keep-alive worker with {interval}s interval")
+
+        last_sent: float | None = None
+
+        while self._running:
+            current_time = time.time()
+            if last_sent is None or current_time - last_sent >= interval:
+                try:
+                    await self._log_keep_alive()
+                except Exception as e:
+                    logger.warning(f"Failed to send keep-alive event: {e}")
+                    # We'll try again on the next interval
+                last_sent = current_time
+            await asyncio.sleep(1)
 
     async def start(self) -> None:
         """Start the worker and begin processing tasks."""
@@ -994,6 +1120,10 @@ class Worker:
         # Start the visibility renewal worker for cloud queues only
         if not self._task_source:
             self._task_list.append(asyncio.create_task(self._visibility_renewal_worker()))
+
+        # Start the keep-alive worker for cloud-based event queues only
+        if self._event_logger_queue is not None and self._data.keepalive_interval > 0:
+            self._task_list.append(asyncio.create_task(self._keepalive_worker()))
 
         # Process tasks until shutdown
         await self._wait_for_shutdown()

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -26,6 +26,11 @@ import requests
 import yaml
 from filecache import FCPath
 
+try:
+    import resource
+except ImportError:  # pragma: no cover - the resource module is unavailable on Windows
+    resource = None  # type: ignore[assignment]
+
 from ..common.logging_config import configure_logging
 from ..common.time_utils import utc_now_iso
 from ..queue_manager import QueueManager, create_queue
@@ -199,6 +204,14 @@ def _parse_args(
         help="Maximum allowed runtime in seconds; used to determine queue visibility "
         "timeout and to kill tasks that are running too long [overrides "
         "$RMS_CLOUD_TASKS_MAX_RUNTIME] (default 3600 seconds)",
+    )
+    parser.add_argument(
+        "--max-memory-allowed-per-task",
+        type=float,
+        help="Maximum memory in GB each task process is allowed to use, enforced by the "
+        "OS as an address-space limit on the process; a task that exceeds it fails with "
+        "a MemoryError and is not retried "
+        "[overrides $RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK] (default no limit)",
     )
     parser.add_argument(
         "--shutdown-grace-period",
@@ -414,6 +427,8 @@ class WorkerData:
         self.price_per_hour: float | None = None  #: The price per hour for the instance
         self.num_simultaneous_tasks: int = 1  #: The number of simultaneous tasks to process
         self.max_runtime: int = 3600  #: The maximum runtime for a task in seconds (1 hour)
+        #: The maximum memory in GB each task process may use (None means no limit)
+        self.max_memory_allowed_per_task: float | None = None
         #: The time in seconds to wait for tasks to complete during shutdown
         self.shutdown_grace_period: int = 30
         self.retry_on_exit: bool = False  #: Whether to retry tasks on premature exit
@@ -712,6 +727,19 @@ class Worker:
             self._data.max_runtime = int(self._data.max_runtime)
         logger.info(f"  Maximum runtime: {self._data.max_runtime} seconds")
 
+        # Get maximum memory allowed per task from args or environment variable
+        raw_max_memory = parsed_args.max_memory_allowed_per_task
+        if raw_max_memory is None:
+            env_val = os.getenv("RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK")
+            raw_max_memory = float(env_val) if env_val is not None else None
+        self._data.max_memory_allowed_per_task = (
+            float(raw_max_memory) if raw_max_memory is not None else None
+        )
+        if self._data.max_memory_allowed_per_task is not None:
+            logger.info(f"  Maximum memory per task: {self._data.max_memory_allowed_per_task} GB")
+        else:
+            logger.info("  Maximum memory per task: No limit")
+
         # Get shutdown grace period from args or environment variable
         self._data.shutdown_grace_period = (
             parsed_args.shutdown_grace_period
@@ -784,6 +812,7 @@ class Worker:
         self._num_tasks_timed_out: int = 0
         self._num_tasks_exited: int = 0
         self._num_tasks_exception: int = 0
+        self._num_tasks_memory_exceeded: int = 0
 
         # Task queue for inter-process communication
         self._result_queue: MP_Queue = cast(MP_Queue, MP_CTX.Queue())
@@ -1133,7 +1162,8 @@ class Worker:
         logger.info(
             f"Task scheduler shutdown complete. Not retried: {self._num_tasks_not_retried}, "
             f"Retried: {self._num_tasks_retried}, Timed out: {self._num_tasks_timed_out}, "
-            f"Exited: {self._num_tasks_exited}, Total: {total}"
+            f"Exited: {self._num_tasks_exited}, "
+            f"Memory exceeded: {self._num_tasks_memory_exceeded}, Total: {total}"
         )
         # We don't log an event here because this only happens when the user hits Ctrl-C
 
@@ -1209,6 +1239,22 @@ class Worker:
                             else:
                                 self._num_tasks_not_retried += 1
                                 await self._queue_acknowledge_task_with_logging(task)
+                        elif retry == "memory_error":
+                            self._num_tasks_memory_exceeded += 1
+                            self._num_tasks_not_retried += 1
+                            logger.warning(
+                                f"Worker #{worker_id} reported task {task['task_id']} exceeded "
+                                "the memory limit"
+                                f"{f' of {self._data.max_memory_allowed_per_task} GB' if self._data.max_memory_allowed_per_task is not None else ''} "
+                                f"in {elapsed_time:.1f} seconds; not retrying"
+                            )
+                            await self._log_task_exception(
+                                task["task_id"],
+                                retry=False,
+                                elapsed_time=elapsed_time,
+                                exception=result,
+                            )
+                            await self._queue_acknowledge_task_with_logging(task)
                         elif retry:
                             self._num_tasks_retried += 1
                             logger.info(
@@ -1694,6 +1740,23 @@ class Worker:
         )
         logger = logging.getLogger(f"worker-{worker_id}")
 
+        # Apply the memory limit, if any, before running the task so the OS enforces it;
+        # allocations beyond the limit fail and raise MemoryError
+        max_memory_gb = worker_data.max_memory_allowed_per_task
+        if max_memory_gb is not None:
+            if resource is None:
+                logger.warning(
+                    f"Worker #{worker_id}: A memory limit was requested but the 'resource' "
+                    "module is not available on this platform; no limit will be applied"
+                )
+            else:
+                max_memory_bytes = int(max_memory_gb * 1024**3)
+                try:
+                    resource.setrlimit(resource.RLIMIT_AS, (max_memory_bytes, max_memory_bytes))
+                    logger.info(f"Worker #{worker_id}: Memory limited to {max_memory_gb} GB")
+                except (ValueError, OSError) as e:
+                    logger.warning(f"Worker #{worker_id}: Failed to set memory limit: {e}")
+
         # Initialize task execution environment
         try:
             logger.info(f"Worker #{worker_id}: Started, processing task {task_id}")
@@ -1717,6 +1780,15 @@ class Worker:
 
                 # Send result back to main process
                 result_queue.put((worker_id, retry, result))
+
+            except MemoryError:
+                logger.error(
+                    f"Worker #{worker_id}: Task {task_id} exceeded the memory limit"
+                    f"{f' of {max_memory_gb} GB' if max_memory_gb is not None else ''}"
+                )
+                # Send failure back to main process; memory limit violations are never
+                # retried
+                result_queue.put((worker_id, "memory_error", str(traceback.format_exc())))
 
             except Exception as e:
                 logger.error(

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -9,6 +9,7 @@ import argparse
 import asyncio
 import json
 import logging
+import math
 import multiprocessing
 import os
 import signal
@@ -736,6 +737,20 @@ class Worker:
             float(raw_max_memory) if raw_max_memory is not None else None
         )
         if self._data.max_memory_allowed_per_task is not None:
+            # A worker configured directly from the command line or the environment
+            # bypasses the manager's RunConfig validation, so check the value here. A
+            # non-finite value would raise while being converted to bytes in each task
+            # process, and a negative one would be rejected by setrlimit and silently
+            # leave the task running with no limit at all.
+            if (
+                not math.isfinite(self._data.max_memory_allowed_per_task)
+                or self._data.max_memory_allowed_per_task <= 0
+            ):
+                logger.error(
+                    "Maximum memory per task must be a positive number of GB, not "
+                    f"{self._data.max_memory_allowed_per_task}"
+                )
+                sys.exit(1)
             logger.info(f"  Maximum memory per task: {self._data.max_memory_allowed_per_task} GB")
         else:
             logger.info("  Maximum memory per task: No limit")

--- a/tests/cloud_tasks/cli/test_event_monitor.py
+++ b/tests/cloud_tasks/cli/test_event_monitor.py
@@ -8,6 +8,7 @@ caplog (pytest.LogCaptureFixture): Captured log records.
 """
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -420,3 +421,191 @@ async def test_event_monitor_keepalive_falls_back_to_hostname(tmp_path: Path) ->
     await monitor.process_events_batch()
     task_db.close()
     assert keepalives == [("host-7", None)]
+
+
+def _stored_event(task_db: TaskDatabase, task_id: str, event_type: str = "task_completed") -> dict:
+    """Insert one event into the database and return it."""
+    event = {
+        "timestamp": "2026-08-18T12:00:00+00:00",
+        "hostname": "host-1",
+        "event_type": event_type,
+        "task_id": task_id,
+        "retry": False,
+        "elapsed_time": 1.5,
+    }
+    task_db.insert_event(event)
+    return event
+
+
+def test_iter_raw_events_streams_in_insertion_order(tmp_path: Path) -> None:
+    """iter_raw_events yields each stored event's raw JSON, oldest first."""
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    for task_id in ("t1", "t2", "t3"):
+        _stored_event(task_db, task_id)
+
+    raw = list(task_db.iter_raw_events())
+    task_db.close()
+
+    assert [json.loads(line)["task_id"] for line in raw] == ["t1", "t2", "t3"]
+
+
+def test_iter_raw_events_empty_database(tmp_path: Path) -> None:
+    """iter_raw_events yields nothing when no events have been recorded."""
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    assert list(task_db.iter_raw_events()) == []
+    task_db.close()
+
+
+@pytest.mark.asyncio
+async def test_start_backfills_new_output_file(tmp_path: Path, caplog) -> None:
+    """A new output file is seeded with the events already in the database."""
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    for task_id in ("t1", "t2"):
+        _stored_event(task_db, task_id)
+    out_file = tmp_path / "events.jsonl"
+
+    monitor = EventMonitor(
+        AsyncMock(),
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+        backfill_output_file=True,
+    )
+    with caplog.at_level(logging.INFO, logger="cloud_tasks.cli"):
+        await monitor.start()
+    monitor.close()
+    task_db.close()
+
+    lines = out_file.read_text().splitlines()
+    assert [json.loads(line)["task_id"] for line in lines] == ["t1", "t2"]
+    assert "Wrote 2 events already in the database" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_backfill_existing_output_file(tmp_path: Path) -> None:
+    """An output file that already exists is appended to, not re-seeded.
+
+    Its contents are presumed to already cover the events in the database, so
+    re-writing them would duplicate every line on each resume.
+    """
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    _stored_event(task_db, "t1")
+    out_file = tmp_path / "events.jsonl"
+    out_file.write_text('{"event_type": "pre-existing"}\n')
+
+    monitor = EventMonitor(
+        AsyncMock(),
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+        backfill_output_file=True,
+    )
+    await monitor.start()
+    monitor.close()
+    task_db.close()
+
+    assert out_file.read_text() == '{"event_type": "pre-existing"}\n'
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_backfill_when_disabled(tmp_path: Path) -> None:
+    """A fresh run leaves the output file empty even though the database has events."""
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    _stored_event(task_db, "t1")
+    out_file = tmp_path / "events.jsonl"
+
+    monitor = EventMonitor(
+        AsyncMock(),
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+    )
+    await monitor.start()
+    monitor.close()
+    task_db.close()
+
+    assert out_file.read_text() == ""
+
+
+@pytest.mark.asyncio
+async def test_backfilled_events_are_followed_by_live_events(tmp_path: Path) -> None:
+    """Events received after the backfill append to it, giving one continuous log."""
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    task_db.insert_task("t2", {})
+    _stored_event(task_db, "t1")
+    out_file = tmp_path / "events.jsonl"
+
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "task_completed", "task_id": "t2", "retry": False}}]
+    )
+    monitor = EventMonitor(
+        mock_queue,
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+        backfill_output_file=True,
+    )
+    await monitor.start()
+    await monitor.process_events_batch()
+    monitor.close()
+    task_db.close()
+
+    lines = out_file.read_text().splitlines()
+    assert [json.loads(line)["task_id"] for line in lines] == ["t1", "t2"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_failure_does_not_abort_monitoring(tmp_path: Path, caplog) -> None:
+    """A failed backfill is logged but leaves the monitor usable.
+
+    The job may already be running, so losing the historical part of the log is
+    preferable to refusing to monitor it.
+    """
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    _stored_event(task_db, "t1")
+    out_file = tmp_path / "events.jsonl"
+
+    monitor = EventMonitor(
+        AsyncMock(),
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+        backfill_output_file=True,
+    )
+    with patch.object(task_db, "iter_raw_events", side_effect=RuntimeError("db gone")):
+        with caplog.at_level(logging.ERROR, logger="cloud_tasks.cli"):
+            await monitor.start()
+
+    assert monitor.output_file is not None
+    assert "Error writing stored events" in caplog.text
+    monitor.close()
+    task_db.close()
+
+
+@pytest.mark.asyncio
+async def test_start_logs_nothing_when_database_has_no_events(tmp_path: Path, caplog) -> None:
+    """Backfilling an empty database creates the file without a misleading log line."""
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    out_file = tmp_path / "events.jsonl"
+
+    monitor = EventMonitor(
+        AsyncMock(),
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+        backfill_output_file=True,
+    )
+    with caplog.at_level(logging.INFO, logger="cloud_tasks.cli"):
+        await monitor.start()
+    monitor.close()
+    task_db.close()
+
+    assert out_file.exists()
+    assert "already in the database" not in caplog.text

--- a/tests/cloud_tasks/cli/test_event_monitor.py
+++ b/tests/cloud_tasks/cli/test_event_monitor.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -560,12 +561,59 @@ async def test_backfilled_events_are_followed_by_live_events(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
-async def test_backfill_failure_does_not_abort_monitoring(tmp_path: Path, caplog) -> None:
-    """A failed backfill is logged and the output file is dropped, but monitoring goes on.
+async def test_backfill_write_failure_drops_the_output_file(tmp_path: Path, caplog) -> None:
+    """An output file that can't be written during the backfill is dropped.
 
-    The job may already be running, so refusing to monitor it would be worse than
-    losing its log file. The stream is disabled rather than kept, because a stream that
-    has already failed would keep failing on every live event.
+    The job may already be running, so refusing to monitor it would be worse than losing
+    its log file. The stream is disabled rather than kept, because a stream that has
+    already failed would keep failing on every live event.
+    """
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    task_db.insert_task("t2", {})
+    _stored_event(task_db, "t1")
+    out_file = tmp_path / "events.jsonl"
+
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "task_completed", "task_id": "t2", "retry": False}}]
+    )
+    monitor = EventMonitor(
+        mock_queue,
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+        backfill_output_file=True,
+    )
+    real_open = open
+
+    def open_with_failing_write(path: str, mode: str) -> Any:
+        """Open the file for real but make writing to it fail."""
+        handle = real_open(path, mode)
+        handle.write = MagicMock(side_effect=OSError("No space left on device"))
+        return handle
+
+    with patch("cloud_tasks.cli.open", side_effect=open_with_failing_write):
+        with caplog.at_level(logging.ERROR, logger="cloud_tasks.cli"):
+            await monitor.start()
+
+    assert monitor.output_file is None
+    assert "No space left on device" in caplog.text
+
+    # Monitoring still works and the database is still updated
+    assert await monitor.process_events_batch() == 1
+    monitor.close()
+    counts = task_db.get_task_counts()
+    task_db.close()
+    assert counts == {"completed": 1}
+
+
+@pytest.mark.asyncio
+async def test_backfill_database_failure_keeps_the_output_file(tmp_path: Path, caplog) -> None:
+    """A database read failure during the backfill says nothing about the output file.
+
+    The file is left open so live events are still logged to it, and the history it is
+    missing is reported rather than silently dropped.
     """
     task_db = TaskDatabase(str(tmp_path / "events.db"))
     task_db.insert_task("t2", {})
@@ -588,15 +636,15 @@ async def test_backfill_failure_does_not_abort_monitoring(tmp_path: Path, caplog
         with caplog.at_level(logging.ERROR, logger="cloud_tasks.cli"):
             await monitor.start()
 
-    assert monitor.output_file is None
-    assert "No longer writing events" in caplog.text
+    assert monitor.output_file is not None
+    assert "Error reading stored events from the database" in caplog.text
 
-    # Monitoring still works and the database is still updated
     assert await monitor.process_events_batch() == 1
     monitor.close()
-    counts = task_db.get_task_counts()
     task_db.close()
-    assert counts == {"completed": 1}
+    # The backfilled history is missing, but live events were still logged
+    lines = out_file.read_text().splitlines()
+    assert [json.loads(line)["task_id"] for line in lines] == ["t2"]
 
 
 @pytest.mark.asyncio

--- a/tests/cloud_tasks/cli/test_event_monitor.py
+++ b/tests/cloud_tasks/cli/test_event_monitor.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -561,17 +561,23 @@ async def test_backfilled_events_are_followed_by_live_events(tmp_path: Path) -> 
 
 @pytest.mark.asyncio
 async def test_backfill_failure_does_not_abort_monitoring(tmp_path: Path, caplog) -> None:
-    """A failed backfill is logged but leaves the monitor usable.
+    """A failed backfill is logged and the output file is dropped, but monitoring goes on.
 
-    The job may already be running, so losing the historical part of the log is
-    preferable to refusing to monitor it.
+    The job may already be running, so refusing to monitor it would be worse than
+    losing its log file. The stream is disabled rather than kept, because a stream that
+    has already failed would keep failing on every live event.
     """
     task_db = TaskDatabase(str(tmp_path / "events.db"))
+    task_db.insert_task("t2", {})
     _stored_event(task_db, "t1")
     out_file = tmp_path / "events.jsonl"
 
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "task_completed", "task_id": "t2", "retry": False}}]
+    )
     monitor = EventMonitor(
-        AsyncMock(),
+        mock_queue,
         task_db,
         output_file_path=str(out_file),
         print_events=False,
@@ -582,10 +588,60 @@ async def test_backfill_failure_does_not_abort_monitoring(tmp_path: Path, caplog
         with caplog.at_level(logging.ERROR, logger="cloud_tasks.cli"):
             await monitor.start()
 
+    assert monitor.output_file is None
+    assert "No longer writing events" in caplog.text
+
+    # Monitoring still works and the database is still updated
+    assert await monitor.process_events_batch() == 1
+    monitor.close()
+    counts = task_db.get_task_counts()
+    task_db.close()
+    assert counts == {"completed": 1}
+
+
+@pytest.mark.asyncio
+async def test_output_file_write_failure_does_not_block_database(tmp_path: Path, caplog) -> None:
+    """A broken output stream is dropped and the database is still updated.
+
+    The database is the authoritative record. If a write error on the optional log file
+    aborted event processing, a full disk would silently stop all task tracking.
+    """
+    task_db = TaskDatabase(str(tmp_path / "events.db"))
+    task_db.insert_task("t1", {})
+    task_db.insert_task("t2", {})
+    out_file = tmp_path / "events.jsonl"
+
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "task_completed", "task_id": "t1", "retry": False}}]
+    )
+    monitor = EventMonitor(
+        mock_queue,
+        task_db,
+        output_file_path=str(out_file),
+        print_events=False,
+        print_summary=False,
+    )
+    await monitor.start()
     assert monitor.output_file is not None
-    assert "Error writing stored events" in caplog.text
+    monitor.output_file.write = MagicMock(side_effect=OSError("No space left on device"))
+
+    with caplog.at_level(logging.ERROR, logger="cloud_tasks.cli"):
+        assert await monitor.process_events_batch() == 1
+
+    assert monitor.output_file is None
+    assert "No space left on device" in caplog.text
+    assert task_db.get_task_counts() == {"completed": 1, "pending": 1}
+
+    # A later event is still recorded even though the file is gone
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "task_completed", "task_id": "t2", "retry": False}}]
+    )
+    assert await monitor.process_events_batch() == 1
+    counts = task_db.get_task_counts()
     monitor.close()
     task_db.close()
+    assert counts == {"completed": 2}
 
 
 @pytest.mark.asyncio

--- a/tests/cloud_tasks/cli/test_event_monitor.py
+++ b/tests/cloud_tasks/cli/test_event_monitor.py
@@ -305,3 +305,118 @@ async def test_run_event_monitoring_loop_process_events_raises(tmp_path: Path) -
             )
     task_db.close()
     assert call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_event_monitor_intercepts_keepalive_events(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Keep-alive events invoke the callback and are not printed, filed, or stored.
+
+    Parameters:
+        tmp_path: Pytest fixture; temporary directory for DB and output file.
+        capsys: Pytest fixture; captured stdout/stderr.
+
+    Returns:
+        None. Asserts callback invocation and absence of keep_alive in outputs.
+    """
+    db_path = tmp_path / "events.db"
+    task_db = TaskDatabase(str(db_path))
+    task_db.insert_task("t1", {})
+    out_file = tmp_path / "events.txt"
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[
+            {
+                "data": {
+                    "event_type": "keep_alive",
+                    "instance_id": "instance-1",
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "hostname": "instance-1",
+                }
+            },
+            {"data": {"task_id": "t1", "event_type": "task_completed", "retry": False}},
+        ]
+    )
+    keepalives: list[tuple[str, str | None]] = []
+    monitor = EventMonitor(
+        mock_queue,
+        task_db,
+        output_file_path=str(out_file),
+        print_events=True,
+        print_summary=False,
+        keepalive_callback=lambda instance_id, timestamp: keepalives.append(
+            (instance_id, timestamp)
+        ),
+    )
+    await monitor.start()
+    count = await monitor.process_events_batch()
+    monitor.close()
+
+    assert count == 2
+    assert keepalives == [("instance-1", "2026-01-01T00:00:00+00:00")]
+    assert "keep_alive" not in out_file.read_text()
+    assert "keep_alive" not in capsys.readouterr().out
+    # The keep-alive event must not be stored in the events table
+    cursor = task_db._get_conn().cursor()
+    cursor.execute("SELECT COUNT(*) FROM events WHERE event_type = 'keep_alive'")
+    assert cursor.fetchone()[0] == 0
+    cursor.execute("SELECT COUNT(*) FROM events")
+    assert cursor.fetchone()[0] == 1
+    task_db.close()
+
+
+@pytest.mark.asyncio
+async def test_event_monitor_keepalive_without_callback(tmp_path: Path) -> None:
+    """Keep-alive events are skipped harmlessly when no callback is registered.
+
+    Parameters:
+        tmp_path: Pytest fixture; temporary directory for the task DB.
+
+    Returns:
+        None. Asserts the batch is processed without errors or DB writes.
+    """
+    db_path = tmp_path / "events.db"
+    task_db = TaskDatabase(str(db_path))
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "keep_alive", "instance_id": "instance-1"}}]
+    )
+    monitor = EventMonitor(mock_queue, task_db, print_events=False, print_summary=False)
+    count = await monitor.process_events_batch()
+    cursor = task_db._get_conn().cursor()
+    cursor.execute("SELECT COUNT(*) FROM events")
+    assert cursor.fetchone()[0] == 0
+    task_db.close()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_event_monitor_keepalive_falls_back_to_hostname(tmp_path: Path) -> None:
+    """Keep-alive events without an instance_id use the hostname for the callback.
+
+    Parameters:
+        tmp_path: Pytest fixture; temporary directory for the task DB.
+
+    Returns:
+        None. Asserts the callback receives the hostname.
+    """
+    db_path = tmp_path / "events.db"
+    task_db = TaskDatabase(str(db_path))
+    mock_queue = AsyncMock()
+    mock_queue.receive_messages = AsyncMock(
+        return_value=[{"data": {"event_type": "keep_alive", "hostname": "host-7"}}]
+    )
+    keepalives: list[tuple[str, str | None]] = []
+    monitor = EventMonitor(
+        mock_queue,
+        task_db,
+        print_events=False,
+        print_summary=False,
+        keepalive_callback=lambda instance_id, timestamp: keepalives.append(
+            (instance_id, timestamp)
+        ),
+    )
+    await monitor.process_events_batch()
+    task_db.close()
+    assert keepalives == [("host-7", None)]

--- a/tests/cloud_tasks/common/test_config.py
+++ b/tests/cloud_tasks/common/test_config.py
@@ -899,3 +899,28 @@ def test_boot_disk_types_capitalization(config_obj):
     c.run.boot_disk_types = []
     c.update_run_config_from_provider_config()
     assert c.run.boot_disk_types == []
+
+
+def test_runconfig_keepalive_fields() -> None:
+    """RunConfig accepts the keep-alive options and rejects invalid values."""
+    config = RunConfig(keepalive_interval=45, keepalive_startup_timeout=600, keepalive_timeout=300)
+    assert config.keepalive_interval == 45
+    assert config.keepalive_startup_timeout == 600
+    assert config.keepalive_timeout == 300
+
+    # Defaults are None (use built-in defaults downstream)
+    config = RunConfig()
+    assert config.keepalive_interval is None
+    assert config.keepalive_startup_timeout is None
+    assert config.keepalive_timeout is None
+
+    # Timeouts may be 0 (disabled), but the interval must be positive
+    config = RunConfig(keepalive_startup_timeout=0, keepalive_timeout=0)
+    assert config.keepalive_startup_timeout == 0
+    assert config.keepalive_timeout == 0
+    with pytest.raises(ValueError):
+        RunConfig(keepalive_interval=0)
+    with pytest.raises(ValueError):
+        RunConfig(keepalive_startup_timeout=-1)
+    with pytest.raises(ValueError):
+        RunConfig(keepalive_timeout=-1)

--- a/tests/cloud_tasks/common/test_config.py
+++ b/tests/cloud_tasks/common/test_config.py
@@ -924,3 +924,18 @@ def test_runconfig_keepalive_fields() -> None:
         RunConfig(keepalive_startup_timeout=-1)
     with pytest.raises(ValueError):
         RunConfig(keepalive_timeout=-1)
+
+
+def test_runconfig_max_memory_allowed_per_task() -> None:
+    """RunConfig accepts max_memory_allowed_per_task and rejects non-positive values."""
+    config = RunConfig(max_memory_allowed_per_task=2.5)
+    assert config.max_memory_allowed_per_task == 2.5
+
+    # Default is None (no limit)
+    config = RunConfig()
+    assert config.max_memory_allowed_per_task is None
+
+    with pytest.raises(ValueError):
+        RunConfig(max_memory_allowed_per_task=0)
+    with pytest.raises(ValueError):
+        RunConfig(max_memory_allowed_per_task=-1)

--- a/tests/cloud_tasks/common/test_config.py
+++ b/tests/cloud_tasks/common/test_config.py
@@ -902,7 +902,13 @@ def test_boot_disk_types_capitalization(config_obj):
 
 
 def test_runconfig_keepalive_fields() -> None:
-    """RunConfig accepts the keep-alive options and rejects invalid values."""
+    """RunConfig validates the keep-alive options.
+
+    Covers: positive values are accepted; all three fields default to None (downstream
+    code substitutes the built-in defaults); the two timeouts accept 0 (which disables
+    that check) but reject negative values; keepalive_interval must be strictly
+    positive (0 and negatives are rejected).
+    """
     config = RunConfig(keepalive_interval=45, keepalive_startup_timeout=600, keepalive_timeout=300)
     assert config.keepalive_interval == 45
     assert config.keepalive_startup_timeout == 600

--- a/tests/cloud_tasks/instance_manager/test_orchestrator.py
+++ b/tests/cloud_tasks/instance_manager/test_orchestrator.py
@@ -268,3 +268,185 @@ async def test_dry_run_prevents_instance_creation(orchestrator):
 
     # Verify that scaling task was not created
     assert orchestrator._scaling_task is None
+
+
+def _make_instance(instance_id: str, state: str = "running") -> dict:
+    """Build a minimal instance dict as returned by list_job_instances."""
+    return {
+        "id": instance_id,
+        "type": "n1-standard-2",
+        "state": state,
+        "zone": "us-central1-a",
+        "creation_time": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def test_record_keepalive(orchestrator):
+    """record_keepalive tracks the last-heard time and that any instance was heard."""
+    assert not orchestrator._keepalive_ever_heard
+    orchestrator.record_keepalive("instance-1", "2026-01-01T00:00:00+00:00")
+    assert "instance-1" in orchestrator._keepalive_last_heard
+    assert orchestrator._keepalive_ever_heard
+    assert orchestrator.keepalive_abort_reason is None
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_terminates_silent_instance(orchestrator):
+    """An instance that stops sending keep-alives is terminated."""
+    import time
+
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    orchestrator._running = True
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[_make_instance("instance-1"), _make_instance("instance-2")]
+    )
+    orchestrator.record_keepalive("instance-1")
+    orchestrator.record_keepalive("instance-2")
+    # instance-2 has been silent for longer than the keep-alive timeout
+    orchestrator._keepalive_last_heard["instance-2"] = time.time() - 400
+
+    await orchestrator._check_keepalives()
+
+    orchestrator._instance_manager.terminate_instance.assert_awaited_once_with(
+        "instance-2", "us-central1-a"
+    )
+    assert "instance-2" not in orchestrator._keepalive_last_heard
+    assert orchestrator.keepalive_abort_reason is None
+    # Terminating a single crashed instance must not stop the whole job
+    assert orchestrator._running is True
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_aborts_when_no_instance_ever_heard(orchestrator):
+    """If every instance misses the startup timeout and none was ever heard, abort the job."""
+    import time
+
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    orchestrator._running = True
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[_make_instance("instance-1"), _make_instance("instance-2")]
+    )
+    orchestrator.terminate_all_instances = AsyncMock()
+    # Both instances were first seen long ago and never sent a keep-alive
+    orchestrator._keepalive_first_seen = {
+        "instance-1": time.time() - 700,
+        "instance-2": time.time() - 700,
+    }
+
+    await orchestrator._check_keepalives()
+
+    orchestrator.terminate_all_instances.assert_awaited_once()
+    assert orchestrator.keepalive_abort_reason is not None
+    assert orchestrator._running is False
+    orchestrator._instance_manager.terminate_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_waits_for_young_instances(orchestrator):
+    """If some instances are still within the startup window, nothing is terminated yet."""
+    import time
+
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    orchestrator._running = True
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[_make_instance("instance-1"), _make_instance("instance-2")]
+    )
+    orchestrator.terminate_all_instances = AsyncMock()
+    # instance-1 is overdue but instance-2 was just seen; nothing was ever heard
+    orchestrator._keepalive_first_seen = {"instance-1": time.time() - 700}
+
+    await orchestrator._check_keepalives()
+
+    orchestrator.terminate_all_instances.assert_not_awaited()
+    orchestrator._instance_manager.terminate_instance.assert_not_awaited()
+    assert orchestrator.keepalive_abort_reason is None
+    assert orchestrator._running is True
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_terminates_startup_failure_when_others_alive(orchestrator):
+    """If other instances are alive, a startup-timeout instance is terminated individually."""
+    import time
+
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    orchestrator._running = True
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[_make_instance("instance-1"), _make_instance("instance-2")]
+    )
+    orchestrator.terminate_all_instances = AsyncMock()
+    orchestrator.record_keepalive("instance-1")
+    orchestrator._keepalive_first_seen = {
+        "instance-1": time.time() - 700,
+        "instance-2": time.time() - 700,
+    }
+
+    await orchestrator._check_keepalives()
+
+    orchestrator.terminate_all_instances.assert_not_awaited()
+    orchestrator._instance_manager.terminate_instance.assert_awaited_once_with(
+        "instance-2", "us-central1-a"
+    )
+    assert orchestrator.keepalive_abort_reason is None
+    assert orchestrator._running is True
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_disabled_timeouts(orchestrator):
+    """Timeouts of 0 disable the keep-alive checks."""
+    import time
+
+    orchestrator._keepalive_startup_timeout = 0.0
+    orchestrator._keepalive_timeout = 0.0
+    orchestrator._running = True
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[_make_instance("instance-1")]
+    )
+    orchestrator.terminate_all_instances = AsyncMock()
+    orchestrator._keepalive_first_seen = {"instance-1": time.time() - 100000}
+    orchestrator.record_keepalive("instance-1")
+    orchestrator._keepalive_last_heard["instance-1"] = time.time() - 100000
+
+    await orchestrator._check_keepalives()
+
+    orchestrator.terminate_all_instances.assert_not_awaited()
+    orchestrator._instance_manager.terminate_instance.assert_not_awaited()
+    assert orchestrator._running is True
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_cleans_up_gone_instances(orchestrator):
+    """Tracking data is dropped for instances that no longer exist."""
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[_make_instance("instance-1")]
+    )
+    orchestrator.record_keepalive("instance-1")
+    orchestrator.record_keepalive("instance-gone")
+    orchestrator._keepalive_first_seen["instance-gone"] = 1.0
+
+    await orchestrator._check_keepalives()
+
+    assert "instance-gone" not in orchestrator._keepalive_last_heard
+    assert "instance-gone" not in orchestrator._keepalive_first_seen
+    assert "instance-1" in orchestrator._keepalive_last_heard
+
+
+def test_startup_script_exports_keepalive_interval(orchestrator, mock_config):
+    """The generated startup script exports the configured keep-alive interval."""
+    mock_config.run.keepalive_interval = 45
+    mock_config.run.startup_script = "#!/bin/bash\necho 'Hello World'"
+    script = orchestrator._generate_worker_startup_script()
+    assert "export RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL=45" in script
+
+
+def test_startup_script_omits_keepalive_interval_when_unset(orchestrator, mock_config):
+    """The generated startup script omits the keep-alive interval when not configured."""
+    mock_config.run.keepalive_interval = None
+    mock_config.run.startup_script = "#!/bin/bash\necho 'Hello World'"
+    script = orchestrator._generate_worker_startup_script()
+    assert "RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL" not in script

--- a/tests/cloud_tasks/instance_manager/test_orchestrator.py
+++ b/tests/cloud_tasks/instance_manager/test_orchestrator.py
@@ -468,3 +468,33 @@ def test_startup_script_omits_max_memory_when_unset(orchestrator, mock_config):
     mock_config.run.startup_script = "#!/bin/bash\necho 'Hello World'"
     script = orchestrator._generate_worker_startup_script()
     assert "RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK" not in script
+
+
+@pytest.mark.asyncio
+async def test_check_keepalives_abort_terminates_starting_instances(orchestrator):
+    """A full abort terminates instances still in the 'starting' state, not just 'running'."""
+    import time
+
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    orchestrator._running = True
+    orchestrator._instance_manager.list_running_instances = AsyncMock(
+        return_value=[
+            _make_instance("instance-1", state="running"),
+            _make_instance("instance-2", state="starting"),
+        ]
+    )
+    orchestrator._keepalive_first_seen = {
+        "instance-1": time.time() - 700,
+        "instance-2": time.time() - 700,
+    }
+
+    # Use the real terminate_all_instances so the state filter is exercised
+    await orchestrator._check_keepalives()
+
+    assert orchestrator.keepalive_abort_reason is not None
+    assert orchestrator._running is False
+    terminated = {
+        call.args[0] for call in orchestrator._instance_manager.terminate_instance.await_args_list
+    }
+    assert terminated == {"instance-1", "instance-2"}

--- a/tests/cloud_tasks/instance_manager/test_orchestrator.py
+++ b/tests/cloud_tasks/instance_manager/test_orchestrator.py
@@ -450,3 +450,21 @@ def test_startup_script_omits_keepalive_interval_when_unset(orchestrator, mock_c
     mock_config.run.startup_script = "#!/bin/bash\necho 'Hello World'"
     script = orchestrator._generate_worker_startup_script()
     assert "RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL" not in script
+
+
+def test_startup_script_exports_max_memory(orchestrator, mock_config):
+    """The generated startup script exports the configured memory limit."""
+    mock_config.run.keepalive_interval = None
+    mock_config.run.max_memory_allowed_per_task = 2.5
+    mock_config.run.startup_script = "#!/bin/bash\necho 'Hello World'"
+    script = orchestrator._generate_worker_startup_script()
+    assert "export RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK=2.5" in script
+
+
+def test_startup_script_omits_max_memory_when_unset(orchestrator, mock_config):
+    """The generated startup script omits the memory limit when not configured."""
+    mock_config.run.keepalive_interval = None
+    mock_config.run.max_memory_allowed_per_task = None
+    mock_config.run.startup_script = "#!/bin/bash\necho 'Hello World'"
+    script = orchestrator._generate_worker_startup_script()
+    assert "RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK" not in script

--- a/tests/cloud_tasks/instance_manager/test_orchestrator.py
+++ b/tests/cloud_tasks/instance_manager/test_orchestrator.py
@@ -1,6 +1,7 @@
 """Unit tests for the InstanceOrchestrator."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -498,3 +499,190 @@ async def test_check_keepalives_abort_terminates_starting_instances(orchestrator
         call.args[0] for call in orchestrator._instance_manager.terminate_instance.await_args_list
     }
     assert terminated == {"instance-1", "instance-2"}
+
+
+def _capture_instance_details(orchestrator, instances, caplog) -> list[str]:
+    """Run _log_instance_details at DEBUG level and return the emitted lines."""
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="cloud_tasks.instance_manager.orchestrator"):
+        orchestrator._log_instance_details(instances)
+    return [record.getMessage() for record in caplog.records]
+
+
+def test_log_instance_details_skipped_without_debug(orchestrator, caplog) -> None:
+    """The instance table costs a line per instance, so it is only emitted at DEBUG."""
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cloud_tasks.instance_manager.orchestrator"):
+        orchestrator._log_instance_details([_make_instance("instance-1")])
+    assert caplog.records == []
+
+
+def test_log_instance_details_no_instances(orchestrator, caplog) -> None:
+    """With no instances the table collapses to a single line, with no header."""
+    lines = _capture_instance_details(orchestrator, [], caplog)
+    assert lines == ["Instance details: no instances"]
+
+
+def test_log_instance_details_rows_sorted_with_details(orchestrator, caplog) -> None:
+    """One row per instance, sorted by ID, carrying the instance's details."""
+    orchestrator._running = True
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    instances = [_make_instance("instance-2"), _make_instance("instance-1", state="starting")]
+
+    lines = _capture_instance_details(orchestrator, instances, caplog)
+
+    assert lines[0] == "Instance details:"
+    assert "Instance ID" in lines[1] and "Keep-Alive" in lines[1] and "Status" in lines[1]
+    # The separator spans the whole table, including rows wider than the header
+    assert set(lines[2].strip()) == {"-"}
+    assert len(lines[2]) == max(len(line) for line in lines[1:])
+    assert len(lines) == 5
+    assert lines[3].split() == [
+        "instance-1",
+        "n1-standard-2",
+        "starting",
+        "us-central1-a",
+        "2026-01-01T00:00:00",
+        "never",
+        "awaiting",
+        "first",
+        "keep-alive",
+    ]
+    assert lines[4].startswith("  instance-2 ")
+
+
+def test_log_instance_details_columns_size_to_content(orchestrator, caplog) -> None:
+    """Columns widen to fit their contents so long GCP instance names stay aligned."""
+    orchestrator._running = True
+    long_id = "rmscr-parallel-addition-job-1riovtucuu1o1dx9lotafw5pb"
+    instances = [
+        _make_instance(long_id),
+        _make_instance("short"),
+    ]
+
+    lines = _capture_instance_details(orchestrator, instances, caplog)
+
+    header, rows = lines[1], lines[3:]
+    assert long_id in rows[0]
+    # Every column of every row starts at the same offset as its header
+    for column in ("Type", "State", "Zone", "Created", "Keep-Alive", "Status"):
+        offset = header.index(column)
+        for row in rows:
+            assert row[offset - 1] == " "
+            assert row[offset] != " "
+
+
+def test_log_instance_details_columns_never_narrower_than_headers(orchestrator, caplog) -> None:
+    """Short values don't squeeze a column below the width of its own header."""
+    orchestrator._running = True
+
+    lines = _capture_instance_details(orchestrator, [_make_instance("i-0abc")], caplog)
+
+    header, row = lines[1], lines[3]
+    assert header.index("Type") == row.index("n1-standard-2")
+    assert header.index("State") == row.index("running")
+
+
+def test_log_instance_details_keepalive_states(orchestrator, caplog) -> None:
+    """Each keep-alive state - healthy, overdue, and never heard from - is reported."""
+    import time
+
+    orchestrator._running = True
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+    now = time.time()
+    instances = [
+        _make_instance("healthy"),
+        _make_instance("silent"),
+        _make_instance("young", state="starting"),
+        _make_instance("never-started"),
+        _make_instance("gone", state="terminated"),
+    ]
+    orchestrator._keepalive_last_heard = {"healthy": now - 60, "silent": now - 400}
+    orchestrator._keepalive_first_seen = {
+        "healthy": now - 1000,
+        "silent": now - 1000,
+        "young": now - 120,
+        "never-started": now - 900,
+    }
+
+    rows = {
+        line.split()[0]: line
+        for line in _capture_instance_details(orchestrator, instances, caplog)[3:]
+    }
+
+    assert "60s ago" in rows["healthy"]
+    assert "OK" in rows["healthy"] and "OVERDUE" not in rows["healthy"]
+
+    assert "400s ago" in rows["silent"]
+    assert "OVERDUE by 100s (limit 300s)" in rows["silent"]
+
+    assert "never" in rows["young"]
+    assert "awaiting first keep-alive (120s of 600s)" in rows["young"]
+
+    assert "never" in rows["never-started"]
+    assert "OVERDUE by 300s for its first keep-alive (limit 600s)" in rows["never-started"]
+
+    # Terminated instances aren't monitored, so they get no keep-alive verdict
+    assert "not active" in rows["gone"]
+
+
+def test_log_instance_details_not_monitored_when_not_running(orchestrator, caplog) -> None:
+    """The status command builds an orchestrator that never receives keep-alives.
+
+    It must not report every healthy worker as silent, so the keep-alive columns say
+    the instances aren't being monitored rather than that they never checked in.
+    """
+    orchestrator._running = False
+    orchestrator._keepalive_startup_timeout = 600.0
+    orchestrator._keepalive_timeout = 300.0
+
+    lines = _capture_instance_details(orchestrator, [_make_instance("instance-1")], caplog)
+
+    assert "not monitored" in lines[3]
+    assert "OVERDUE" not in lines[3]
+
+
+def test_log_instance_details_not_monitored_when_timeouts_disabled(orchestrator, caplog) -> None:
+    """With both timeouts disabled there is nothing to be overdue against."""
+    orchestrator._running = True
+    orchestrator._keepalive_startup_timeout = 0.0
+    orchestrator._keepalive_timeout = 0.0
+
+    lines = _capture_instance_details(orchestrator, [_make_instance("instance-1")], caplog)
+
+    assert "not monitored" in lines[3]
+
+
+def test_log_instance_details_azure_missing_fields(orchestrator, caplog) -> None:
+    """Azure instances report a location and no creation time; the row still renders."""
+    orchestrator._running = True
+    instance = {
+        "id": "azure-vm-1",
+        "type": "Standard_D4s_v3",
+        "state": "running",
+        "location": "eastus",
+    }
+
+    lines = _capture_instance_details(orchestrator, [instance], caplog)
+
+    assert "azure-vm-1" in lines[3]
+    assert "eastus" in lines[3]
+
+
+@pytest.mark.asyncio
+async def test_get_job_instances_logs_instance_details(orchestrator) -> None:
+    """The instance summary is preceded by the per-instance debug table."""
+    instances = [_make_instance("instance-1")]
+    orchestrator.list_job_instances = AsyncMock(return_value=instances)
+    orchestrator._initialize_pricing_info = AsyncMock()
+    orchestrator._all_instance_info = {"n1-standard-2": {"vcpu": 2}}
+    orchestrator._pricing_info = {
+        "n1-standard-2": {"us-central1-a": {"pd-balanced": {"total_price": 1.0}}}
+    }
+
+    with patch.object(orchestrator, "_log_instance_details") as mock_log:
+        await orchestrator.get_job_instances()
+
+    mock_log.assert_called_once_with(instances)

--- a/tests/cloud_tasks/queue_manager/test_gcp.py
+++ b/tests/cloud_tasks/queue_manager/test_gcp.py
@@ -772,6 +772,50 @@ async def test_acknowledge_task_error(gcp_queue, mock_pubsub_client):
     assert "invalid" in str(exc_info.value).lower() or "ack" in str(exc_info.value).lower()
 
 
+def test_get_max_visibility_timeout(gcp_queue):
+    """Test that the maximum visibility timeout matches GCP's 600-second ack deadline limit."""
+    assert gcp_queue.get_max_visibility_timeout() == 600
+
+
+@pytest.mark.asyncio
+async def test_extend_message_visibility_clips_to_maximum(gcp_queue, mock_pubsub_client):
+    """Test that extend_message_visibility clips timeouts above GCP's 600-second maximum."""
+    mock_publisher, mock_subscriber = mock_pubsub_client
+
+    await gcp_queue.extend_message_visibility("test-ack-id", 10000)
+
+    mock_subscriber.modify_ack_deadline.assert_called_once_with(
+        request={
+            "subscription": gcp_queue._subscription_path,
+            "ack_ids": ["test-ack-id"],
+            "ack_deadline_seconds": 600,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_extend_message_visibility_below_maximum(gcp_queue, mock_pubsub_client):
+    """Test that extend_message_visibility passes through timeouts below the maximum."""
+    mock_publisher, mock_subscriber = mock_pubsub_client
+
+    await gcp_queue.extend_message_visibility("test-ack-id", 120)
+
+    mock_subscriber.modify_ack_deadline.assert_called_once_with(
+        request={
+            "subscription": gcp_queue._subscription_path,
+            "ack_ids": ["test-ack-id"],
+            "ack_deadline_seconds": 120,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_visibility_timeout_capped_at_gcp_maximum(mock_pubsub_client, gcp_config):
+    """Test that a visibility_timeout above GCP's maximum is capped at 600 seconds."""
+    queue = GCPPubSubQueue(gcp_config, visibility_timeout=10010)
+    assert queue._visibility_timeout == 600
+
+
 @pytest.mark.asyncio
 async def test_retry_task_error(gcp_queue, mock_pubsub_client):
     """Test error handling during task failure."""

--- a/tests/cloud_tasks/queue_manager/test_gcp.py
+++ b/tests/cloud_tasks/queue_manager/test_gcp.py
@@ -19,6 +19,13 @@ from google.api_core import exceptions as gcp_exceptions
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from cloud_tasks.queue_manager.gcp import GCPPubSubQueue  # noqa
 
+#: The maximum ack deadline GCP Pub/Sub accepts, per its published limits. Deliberately
+#: spelled out here instead of read from GCPPubSubQueue._MAXIMUM_VISIBILITY_TIMEOUT: these
+#: tests exist to pin that constant to the real GCP limit, and sourcing the expected value
+#: from the code under test would make them pass for any value at all - which is how the
+#: constant sat at 30 seconds undetected.
+GCP_MAX_ACK_DEADLINE_SECONDS = 600
+
 # Filter coroutine warnings for these tests
 warnings.filterwarnings("ignore", message="coroutine .* was never awaited")
 
@@ -773,16 +780,16 @@ async def test_acknowledge_task_error(gcp_queue, mock_pubsub_client):
 
 
 def test_get_max_visibility_timeout(gcp_queue: GCPPubSubQueue) -> None:
-    """Test that the maximum visibility timeout matches GCP's 600-second ack
+    """Test that the maximum visibility timeout matches GCP's published ack
     deadline limit."""
-    assert gcp_queue.get_max_visibility_timeout() == 600
+    assert gcp_queue.get_max_visibility_timeout() == GCP_MAX_ACK_DEADLINE_SECONDS
 
 
 @pytest.mark.asyncio
 async def test_extend_message_visibility_clips_to_maximum(
     gcp_queue: GCPPubSubQueue, mock_pubsub_client: tuple[MagicMock, MagicMock]
 ) -> None:
-    """Test that extend_message_visibility clips timeouts above GCP's 600-second maximum."""
+    """Test that extend_message_visibility clips timeouts above GCP's maximum."""
     mock_publisher, mock_subscriber = mock_pubsub_client
 
     await gcp_queue.extend_message_visibility("test-ack-id", 10000)
@@ -791,7 +798,7 @@ async def test_extend_message_visibility_clips_to_maximum(
         request={
             "subscription": gcp_queue._subscription_path,
             "ack_ids": ["test-ack-id"],
-            "ack_deadline_seconds": 600,
+            "ack_deadline_seconds": GCP_MAX_ACK_DEADLINE_SECONDS,
         }
     )
 
@@ -818,9 +825,9 @@ async def test_extend_message_visibility_below_maximum(
 async def test_visibility_timeout_capped_at_gcp_maximum(
     mock_pubsub_client: tuple[MagicMock, MagicMock], gcp_config: MagicMock
 ) -> None:
-    """Test that a visibility_timeout above GCP's maximum is capped at 600 seconds."""
+    """Test that a visibility_timeout above GCP's maximum is capped at that maximum."""
     queue = GCPPubSubQueue(gcp_config, visibility_timeout=10010)
-    assert queue._visibility_timeout == 600
+    assert queue._visibility_timeout == GCP_MAX_ACK_DEADLINE_SECONDS
 
 
 @pytest.mark.asyncio

--- a/tests/cloud_tasks/queue_manager/test_gcp.py
+++ b/tests/cloud_tasks/queue_manager/test_gcp.py
@@ -773,7 +773,8 @@ async def test_acknowledge_task_error(gcp_queue, mock_pubsub_client):
 
 
 def test_get_max_visibility_timeout(gcp_queue: GCPPubSubQueue) -> None:
-    """Test that the maximum visibility timeout matches GCP's 600-second ack deadline limit."""
+    """Test that the maximum visibility timeout matches GCP's 600-second ack
+    deadline limit."""
     assert gcp_queue.get_max_visibility_timeout() == 600
 
 

--- a/tests/cloud_tasks/queue_manager/test_gcp.py
+++ b/tests/cloud_tasks/queue_manager/test_gcp.py
@@ -772,13 +772,15 @@ async def test_acknowledge_task_error(gcp_queue, mock_pubsub_client):
     assert "invalid" in str(exc_info.value).lower() or "ack" in str(exc_info.value).lower()
 
 
-def test_get_max_visibility_timeout(gcp_queue):
+def test_get_max_visibility_timeout(gcp_queue: GCPPubSubQueue) -> None:
     """Test that the maximum visibility timeout matches GCP's 600-second ack deadline limit."""
     assert gcp_queue.get_max_visibility_timeout() == 600
 
 
 @pytest.mark.asyncio
-async def test_extend_message_visibility_clips_to_maximum(gcp_queue, mock_pubsub_client):
+async def test_extend_message_visibility_clips_to_maximum(
+    gcp_queue: GCPPubSubQueue, mock_pubsub_client: tuple[MagicMock, MagicMock]
+) -> None:
     """Test that extend_message_visibility clips timeouts above GCP's 600-second maximum."""
     mock_publisher, mock_subscriber = mock_pubsub_client
 
@@ -794,7 +796,9 @@ async def test_extend_message_visibility_clips_to_maximum(gcp_queue, mock_pubsub
 
 
 @pytest.mark.asyncio
-async def test_extend_message_visibility_below_maximum(gcp_queue, mock_pubsub_client):
+async def test_extend_message_visibility_below_maximum(
+    gcp_queue: GCPPubSubQueue, mock_pubsub_client: tuple[MagicMock, MagicMock]
+) -> None:
     """Test that extend_message_visibility passes through timeouts below the maximum."""
     mock_publisher, mock_subscriber = mock_pubsub_client
 
@@ -810,7 +814,9 @@ async def test_extend_message_visibility_below_maximum(gcp_queue, mock_pubsub_cl
 
 
 @pytest.mark.asyncio
-async def test_visibility_timeout_capped_at_gcp_maximum(mock_pubsub_client, gcp_config):
+async def test_visibility_timeout_capped_at_gcp_maximum(
+    mock_pubsub_client: tuple[MagicMock, MagicMock], gcp_config: MagicMock
+) -> None:
     """Test that a visibility_timeout above GCP's maximum is capped at 600 seconds."""
     queue = GCPPubSubQueue(gcp_config, visibility_timeout=10010)
     assert queue._visibility_timeout == 600

--- a/tests/cloud_tasks/worker/conftest.py
+++ b/tests/cloud_tasks/worker/conftest.py
@@ -11,6 +11,7 @@ parsing from environment.
 
 import json
 import os
+import pathlib
 import sys
 import tempfile
 from collections.abc import Callable, Generator, Iterable
@@ -21,6 +22,19 @@ import pytest
 import yaml
 
 from cloud_tasks.worker.worker import Worker
+
+
+@pytest.fixture(autouse=True)
+def run_in_tmp_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run every worker test in its own temporary directory.
+
+    A Worker created with a task_source defaults to logging events to a file, and the
+    default event log file name ("events.log") is relative, so a worker started by a
+    test appends to whatever directory pytest was invoked from - normally the top of
+    the repository. This fixture redirects those writes into the test's tmp_path
+    instead of leaving them in the working tree, where .gitignore's "*.log" hides them.
+    """
+    monkeypatch.chdir(tmp_path)
 
 
 def _mock_worker_function(task_id: str, task_data: dict[str, Any], worker: Any) -> tuple[bool, str]:

--- a/tests/cloud_tasks/worker/test_worker_init.py
+++ b/tests/cloud_tasks/worker/test_worker_init.py
@@ -28,6 +28,7 @@ _DEFAULT_ARGS = {
     "price": None,
     "num_simultaneous_tasks": None,
     "max_runtime": None,
+    "max_memory_allowed_per_task": None,
     "shutdown_grace_period": None,
     "tasks_to_skip": None,
     "max_num_tasks": None,

--- a/tests/cloud_tasks/worker/test_worker_init.py
+++ b/tests/cloud_tasks/worker/test_worker_init.py
@@ -36,6 +36,7 @@ _DEFAULT_ARGS = {
     "event_log_to_file": None,
     "event_log_file": None,
     "event_log_to_queue": False,
+    "keepalive_interval": None,
     "verbose": False,
     "retry_on_timeout": None,
     "retry_on_exception": None,

--- a/tests/cloud_tasks/worker/test_worker_keepalive.py
+++ b/tests/cloud_tasks/worker/test_worker_keepalive.py
@@ -1,0 +1,160 @@
+"""Tests for the worker keep-alive event support."""
+
+import asyncio
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloud_tasks.worker.worker import Worker
+
+
+@pytest.fixture
+def keepalive_worker(mock_worker_function, monkeypatch) -> Worker:
+    """Worker instance with provider and job-id from env; sys.argv patched for test scope."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py"])
+    return Worker(mock_worker_function)
+
+
+def test_keepalive_interval_default(keepalive_worker: Worker) -> None:
+    """The keep-alive interval defaults to 60 seconds."""
+    assert keepalive_worker._data.keepalive_interval == 60.0
+
+
+def test_keepalive_interval_from_env(mock_worker_function, monkeypatch) -> None:
+    """The keep-alive interval can be set via RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL", "120")
+    monkeypatch.setattr(sys, "argv", ["worker.py"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.keepalive_interval == 120.0
+
+
+def test_keepalive_interval_from_args(mock_worker_function, monkeypatch) -> None:
+    """The keep-alive interval can be set via --keepalive-interval, overriding the env var."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL", "120")
+    monkeypatch.setattr(sys, "argv", ["worker.py", "--keepalive-interval", "30"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.keepalive_interval == 30.0
+
+
+@pytest.mark.asyncio
+async def test_log_keep_alive_sends_to_queue_only(keepalive_worker: Worker) -> None:
+    """Keep-alive events go to the event queue with instance_id and timestamp, never to file."""
+    keepalive_worker._instance_identity = "test-instance-1"
+    keepalive_worker._event_logger_queue = AsyncMock()
+    keepalive_worker._event_logger_fp = MagicMock()
+
+    await keepalive_worker._log_keep_alive()
+
+    keepalive_worker._event_logger_fp.write.assert_not_called()
+    keepalive_worker._event_logger_queue.send_message.assert_awaited_once()
+    event = keepalive_worker._event_logger_queue.send_message.await_args.args[0]
+    assert event["event_type"] == "keep_alive"
+    assert event["instance_id"] == "test-instance-1"
+    assert event["timestamp"]
+    assert event["hostname"] == keepalive_worker._hostname
+
+
+def test_get_instance_identity_gcp(keepalive_worker: Worker) -> None:
+    """The instance identity is fetched from the GCP metadata server and cached."""
+    response = MagicMock(status_code=200, text="gcp-instance-name\n")
+    with patch("cloud_tasks.worker.worker.requests.get", return_value=response) as mock_get:
+        assert keepalive_worker._get_instance_identity() == "gcp-instance-name"
+        # Second call uses the cached value
+        assert keepalive_worker._get_instance_identity() == "gcp-instance-name"
+        assert mock_get.call_count == 1
+        assert "metadata.google.internal" in mock_get.call_args.args[0]
+
+
+def test_get_instance_identity_aws(mock_worker_function, monkeypatch) -> None:
+    """The instance identity is fetched from the AWS metadata server."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "AWS")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py"])
+    worker = Worker(mock_worker_function)
+
+    token_response = MagicMock(status_code=200, text="imds-token")
+    id_response = MagicMock(status_code=200, text="i-0123456789abcdef0")
+    with (
+        patch("cloud_tasks.worker.worker.requests.put", return_value=token_response),
+        patch("cloud_tasks.worker.worker.requests.get", return_value=id_response) as mock_get,
+    ):
+        assert worker._get_instance_identity() == "i-0123456789abcdef0"
+        assert mock_get.call_args.kwargs["headers"] == {"X-aws-ec2-metadata-token": "imds-token"}
+
+
+def test_get_instance_identity_fallback_to_hostname(keepalive_worker: Worker) -> None:
+    """The instance identity falls back to the hostname if the metadata server is unreachable."""
+    with patch(
+        "cloud_tasks.worker.worker.requests.get", side_effect=ConnectionError("no metadata")
+    ):
+        assert keepalive_worker._get_instance_identity() == keepalive_worker._hostname
+
+
+@pytest.mark.asyncio
+async def test_keepalive_worker_sends_and_stops(keepalive_worker: Worker) -> None:
+    """The keep-alive worker sends an event immediately and stops when the worker stops."""
+    keepalive_worker._running = True
+    keepalive_worker._data.keepalive_interval = 60.0
+    with patch.object(keepalive_worker, "_log_keep_alive", new_callable=AsyncMock) as mock_log:
+        task = asyncio.create_task(keepalive_worker._keepalive_worker())
+        await asyncio.sleep(0.1)
+        keepalive_worker._running = False
+        await task
+    mock_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_worker_survives_send_errors(keepalive_worker: Worker) -> None:
+    """The keep-alive worker keeps running if sending an event fails."""
+    keepalive_worker._running = True
+    keepalive_worker._data.keepalive_interval = 60.0
+    with patch.object(
+        keepalive_worker,
+        "_log_keep_alive",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("queue unavailable"),
+    ) as mock_log:
+        task = asyncio.create_task(keepalive_worker._keepalive_worker())
+        await asyncio.sleep(0.1)
+        keepalive_worker._running = False
+        await task
+    mock_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_worker_started_only_with_event_queue(
+    mock_worker_function, monkeypatch
+) -> None:
+    """start() launches the keep-alive worker only when logging events to a queue."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py", "--no-event-log-to-queue"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.event_log_to_queue is False
+
+    started: list[Any] = []
+
+    async def fake_feed() -> None:
+        worker._running = False
+
+    with (
+        patch.object(worker, "_keepalive_worker", new_callable=AsyncMock) as mock_keepalive,
+        patch.object(worker, "_handle_results", new_callable=AsyncMock),
+        patch.object(worker, "_feed_tasks_to_workers", side_effect=fake_feed),
+        patch.object(worker, "_monitor_process_runtimes", new_callable=AsyncMock),
+        patch.object(worker, "_visibility_renewal_worker", new_callable=AsyncMock),
+        patch.object(worker, "_wait_for_shutdown", new_callable=AsyncMock),
+        patch("cloud_tasks.worker.worker.create_queue", new_callable=AsyncMock),
+    ):
+        await worker.start()
+        started = [mock_keepalive.call_count]
+
+    assert started == [0]

--- a/tests/cloud_tasks/worker/test_worker_keepalive.py
+++ b/tests/cloud_tasks/worker/test_worker_keepalive.py
@@ -8,11 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from cloud_tasks.worker.worker import Worker
+from cloud_tasks.worker.worker import Worker, WorkerData
 
 #: Signature of the callable a Worker is constructed with, as built by the
-#: mock_worker_function fixture: (task_id, task_data, worker) -> (retry, result).
-WorkerFunction = Callable[[str, dict[str, Any], Any], tuple[bool, str]]
+#: mock_worker_function fixture: (task_id, task_data, worker_data) -> (retry, result).
+WorkerFunction = Callable[[str, dict[str, Any], WorkerData], tuple[bool, str]]
 
 
 @pytest.fixture

--- a/tests/cloud_tasks/worker/test_worker_keepalive.py
+++ b/tests/cloud_tasks/worker/test_worker_keepalive.py
@@ -91,11 +91,20 @@ def test_get_instance_identity_aws(mock_worker_function, monkeypatch) -> None:
 
 
 def test_get_instance_identity_fallback_to_hostname(keepalive_worker: Worker) -> None:
-    """The instance identity falls back to the hostname if the metadata server is unreachable."""
+    """The hostname fallback is not cached, so the metadata server is retried later."""
     with patch(
         "cloud_tasks.worker.worker.requests.get", side_effect=ConnectionError("no metadata")
-    ):
+    ) as mock_get:
         assert keepalive_worker._get_instance_identity() == keepalive_worker._hostname
+        assert keepalive_worker._get_instance_identity() == keepalive_worker._hostname
+        # The fallback must not be cached; each call retries the metadata server
+        assert mock_get.call_count == 2
+
+    # Once the metadata server recovers, its answer is used and cached
+    response = MagicMock(status_code=200, text="gcp-instance-name\n")
+    with patch("cloud_tasks.worker.worker.requests.get", return_value=response):
+        assert keepalive_worker._get_instance_identity() == "gcp-instance-name"
+    assert keepalive_worker._get_instance_identity() == "gcp-instance-name"
 
 
 @pytest.mark.asyncio

--- a/tests/cloud_tasks/worker/test_worker_keepalive.py
+++ b/tests/cloud_tasks/worker/test_worker_keepalive.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,9 +10,15 @@ import pytest
 
 from cloud_tasks.worker.worker import Worker
 
+#: Signature of the callable a Worker is constructed with, as built by the
+#: mock_worker_function fixture: (task_id, task_data, worker) -> (retry, result).
+WorkerFunction = Callable[[str, dict[str, Any], Any], tuple[bool, str]]
+
 
 @pytest.fixture
-def keepalive_worker(mock_worker_function, monkeypatch) -> Worker:
+def keepalive_worker(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> Worker:
     """Worker instance with provider and job-id from env; sys.argv patched for test scope."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -24,7 +31,9 @@ def test_keepalive_interval_default(keepalive_worker: Worker) -> None:
     assert keepalive_worker._data.keepalive_interval == 60.0
 
 
-def test_keepalive_interval_from_env(mock_worker_function, monkeypatch) -> None:
+def test_keepalive_interval_from_env(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The keep-alive interval can be set via RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -34,7 +43,9 @@ def test_keepalive_interval_from_env(mock_worker_function, monkeypatch) -> None:
     assert worker._data.keepalive_interval == 120.0
 
 
-def test_keepalive_interval_from_args(mock_worker_function, monkeypatch) -> None:
+def test_keepalive_interval_from_args(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The keep-alive interval can be set via --keepalive-interval, overriding the env var."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -73,7 +84,9 @@ def test_get_instance_identity_gcp(keepalive_worker: Worker) -> None:
         assert "metadata.google.internal" in mock_get.call_args.args[0]
 
 
-def test_get_instance_identity_aws(mock_worker_function, monkeypatch) -> None:
+def test_get_instance_identity_aws(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The instance identity is fetched from the AWS metadata server."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "AWS")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -140,7 +153,7 @@ async def test_keepalive_worker_survives_send_errors(keepalive_worker: Worker) -
 
 @pytest.mark.asyncio
 async def test_keepalive_worker_started_only_with_event_queue(
-    mock_worker_function, monkeypatch
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """start() launches the keep-alive worker only when logging events to a queue."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")

--- a/tests/cloud_tasks/worker/test_worker_memory.py
+++ b/tests/cloud_tasks/worker/test_worker_memory.py
@@ -1,8 +1,10 @@
 """Tests for the per-task memory limit support."""
 
 import asyncio
+import logging
 import sys
 import time
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
@@ -10,8 +12,14 @@ import pytest
 
 from cloud_tasks.worker.worker import Worker
 
+#: Signature of the callable a Worker is constructed with, as built by the
+#: mock_worker_function fixture: (task_id, task_data, worker) -> (retry, result).
+WorkerFunction = Callable[[str, dict[str, Any], Any], tuple[bool, str]]
 
-def test_max_memory_default_no_limit(mock_worker_function, monkeypatch) -> None:
+
+def test_max_memory_default_no_limit(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The maximum memory per task defaults to None (no limit)."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -20,7 +28,9 @@ def test_max_memory_default_no_limit(mock_worker_function, monkeypatch) -> None:
     assert worker._data.max_memory_allowed_per_task is None
 
 
-def test_max_memory_from_env(mock_worker_function, monkeypatch) -> None:
+def test_max_memory_from_env(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The maximum memory per task can be set via the environment variable."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -30,7 +40,9 @@ def test_max_memory_from_env(mock_worker_function, monkeypatch) -> None:
     assert worker._data.max_memory_allowed_per_task == 2.5
 
 
-def test_max_memory_from_args(mock_worker_function, monkeypatch) -> None:
+def test_max_memory_from_args(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """--max-memory-allowed-per-task overrides the environment variable."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
@@ -49,7 +61,7 @@ def _worker_data_mock(max_memory_gb: float | None) -> MagicMock:
     return worker_data
 
 
-def test_worker_process_main_sets_memory_limit(mock_worker_function) -> None:
+def test_worker_process_main_sets_memory_limit(mock_worker_function: WorkerFunction) -> None:
     """_worker_process_main applies the memory limit via resource.setrlimit."""
     result_queue = MagicMock()
     worker_data = _worker_data_mock(2.0)
@@ -70,7 +82,7 @@ def test_worker_process_main_sets_memory_limit(mock_worker_function) -> None:
     result_queue.put.assert_called_once_with((1, False, "success"))
 
 
-def test_worker_process_main_no_memory_limit(mock_worker_function) -> None:
+def test_worker_process_main_no_memory_limit(mock_worker_function: WorkerFunction) -> None:
     """_worker_process_main does not touch rlimits when no limit is configured."""
     result_queue = MagicMock()
     worker_data = _worker_data_mock(None)
@@ -88,7 +100,9 @@ def test_worker_process_main_no_memory_limit(mock_worker_function) -> None:
     result_queue.put.assert_called_once_with((1, False, "success"))
 
 
-def test_worker_process_main_memory_limit_without_resource_module(mock_worker_function) -> None:
+def test_worker_process_main_memory_limit_without_resource_module(
+    mock_worker_function: WorkerFunction, caplog: pytest.LogCaptureFixture
+) -> None:
     """A configured memory limit is skipped with a warning when resource is unavailable."""
     result_queue = MagicMock()
     worker_data = _worker_data_mock(2.0)
@@ -96,16 +110,25 @@ def test_worker_process_main_memory_limit_without_resource_module(mock_worker_fu
     with (
         patch("cloud_tasks.worker.worker.resource", None),
         patch("sys.exit"),
+        caplog.at_level(logging.WARNING, logger="cloud_tasks.worker.worker"),
     ):
         Worker._worker_process_main(
             1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
         )
 
+    # The caller must be told the limit they asked for is not in effect
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "'resource' module is not available" in m and "no limit will be applied" in m
+        for m in warnings
+    ), warnings
     # The task still runs normally
     result_queue.put.assert_called_once_with((1, False, "success"))
 
 
-def test_worker_process_main_setrlimit_failure(mock_worker_function) -> None:
+def test_worker_process_main_setrlimit_failure(
+    mock_worker_function: WorkerFunction, caplog: pytest.LogCaptureFixture
+) -> None:
     """A setrlimit failure is logged as a warning and the task still runs."""
     result_queue = MagicMock()
     worker_data = _worker_data_mock(2.0)
@@ -115,15 +138,20 @@ def test_worker_process_main_setrlimit_failure(mock_worker_function) -> None:
     with (
         patch("cloud_tasks.worker.worker.resource", mock_resource),
         patch("sys.exit"),
+        caplog.at_level(logging.WARNING, logger="cloud_tasks.worker.worker"),
     ):
         Worker._worker_process_main(
             1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
         )
 
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "Failed to set memory limit" in m and "cannot raise hard limit" in m for m in warnings
+    ), warnings
     result_queue.put.assert_called_once_with((1, False, "success"))
 
 
-def test_worker_process_main_memory_error(mock_worker_function) -> None:
+def test_worker_process_main_memory_error(mock_worker_function: WorkerFunction) -> None:
     """A MemoryError from the task is reported as a memory_error result."""
 
     def oom_worker_function(task_id: str, task_data: dict[str, Any], worker: Any):
@@ -238,3 +266,36 @@ async def test_handle_results_memory_error_logs_nonretriable_exception_event(
     mock_log.assert_awaited_once_with(
         "task1", retry=False, elapsed_time=ANY, exception="MemoryError traceback"
     )
+
+
+@pytest.mark.parametrize("bad_value", ["-1", "0", "nan", "inf"])
+def test_max_memory_rejects_invalid_values(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch, bad_value: str
+) -> None:
+    """A non-positive or non-finite memory limit is rejected during worker startup.
+
+    A worker configured from the command line or the environment doesn't go through the
+    manager's RunConfig validation. Left unchecked, a non-finite value raises while being
+    converted to bytes in every task process, and a negative one is rejected by setrlimit
+    and leaves the task running with no limit at all despite one having been requested.
+    """
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py", "--max-memory-allowed-per-task", bad_value])
+
+    with patch("cloud_tasks.worker.worker.sys.exit", side_effect=SystemExit(1)) as mock_exit:
+        with pytest.raises(SystemExit):
+            Worker(mock_worker_function)
+
+    mock_exit.assert_called_once_with(1)
+
+
+def test_max_memory_accepts_small_positive_value(
+    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A small but positive memory limit is accepted."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py", "--max-memory-allowed-per-task", "0.25"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.max_memory_allowed_per_task == 0.25

--- a/tests/cloud_tasks/worker/test_worker_memory.py
+++ b/tests/cloud_tasks/worker/test_worker_memory.py
@@ -1,0 +1,240 @@
+"""Tests for the per-task memory limit support."""
+
+import asyncio
+import sys
+import time
+from typing import Any
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+from cloud_tasks.worker.worker import Worker
+
+
+def test_max_memory_default_no_limit(mock_worker_function, monkeypatch) -> None:
+    """The maximum memory per task defaults to None (no limit)."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.max_memory_allowed_per_task is None
+
+
+def test_max_memory_from_env(mock_worker_function, monkeypatch) -> None:
+    """The maximum memory per task can be set via the environment variable."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK", "2.5")
+    monkeypatch.setattr(sys, "argv", ["worker.py"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.max_memory_allowed_per_task == 2.5
+
+
+def test_max_memory_from_args(mock_worker_function, monkeypatch) -> None:
+    """--max-memory-allowed-per-task overrides the environment variable."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK", "2.5")
+    monkeypatch.setattr(sys, "argv", ["worker.py", "--max-memory-allowed-per-task", "4"])
+    worker = Worker(mock_worker_function)
+    assert worker._data.max_memory_allowed_per_task == 4.0
+
+
+def _worker_data_mock(max_memory_gb: float | None) -> MagicMock:
+    """Build a mock WorkerData with the given memory limit."""
+    worker_data = MagicMock()
+    worker_data.max_memory_allowed_per_task = max_memory_gb
+    worker_data.received_shutdown_request = False
+    worker_data.received_termination_notice = False
+    return worker_data
+
+
+def test_worker_process_main_sets_memory_limit(mock_worker_function) -> None:
+    """_worker_process_main applies the memory limit via resource.setrlimit."""
+    result_queue = MagicMock()
+    worker_data = _worker_data_mock(2.0)
+    mock_resource = MagicMock()
+
+    with (
+        patch("cloud_tasks.worker.worker.resource", mock_resource),
+        patch("sys.exit"),
+    ):
+        Worker._worker_process_main(
+            1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
+        )
+
+    expected_bytes = int(2.0 * 1024**3)
+    mock_resource.setrlimit.assert_called_once_with(
+        mock_resource.RLIMIT_AS, (expected_bytes, expected_bytes)
+    )
+    result_queue.put.assert_called_once_with((1, False, "success"))
+
+
+def test_worker_process_main_no_memory_limit(mock_worker_function) -> None:
+    """_worker_process_main does not touch rlimits when no limit is configured."""
+    result_queue = MagicMock()
+    worker_data = _worker_data_mock(None)
+    mock_resource = MagicMock()
+
+    with (
+        patch("cloud_tasks.worker.worker.resource", mock_resource),
+        patch("sys.exit"),
+    ):
+        Worker._worker_process_main(
+            1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
+        )
+
+    mock_resource.setrlimit.assert_not_called()
+    result_queue.put.assert_called_once_with((1, False, "success"))
+
+
+def test_worker_process_main_memory_limit_without_resource_module(mock_worker_function) -> None:
+    """A configured memory limit is skipped with a warning when resource is unavailable."""
+    result_queue = MagicMock()
+    worker_data = _worker_data_mock(2.0)
+
+    with (
+        patch("cloud_tasks.worker.worker.resource", None),
+        patch("sys.exit"),
+    ):
+        Worker._worker_process_main(
+            1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
+        )
+
+    # The task still runs normally
+    result_queue.put.assert_called_once_with((1, False, "success"))
+
+
+def test_worker_process_main_setrlimit_failure(mock_worker_function) -> None:
+    """A setrlimit failure is logged as a warning and the task still runs."""
+    result_queue = MagicMock()
+    worker_data = _worker_data_mock(2.0)
+    mock_resource = MagicMock()
+    mock_resource.setrlimit.side_effect = ValueError("cannot raise hard limit")
+
+    with (
+        patch("cloud_tasks.worker.worker.resource", mock_resource),
+        patch("sys.exit"),
+    ):
+        Worker._worker_process_main(
+            1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
+        )
+
+    result_queue.put.assert_called_once_with((1, False, "success"))
+
+
+def test_worker_process_main_memory_error(mock_worker_function) -> None:
+    """A MemoryError from the task is reported as a memory_error result."""
+
+    def oom_worker_function(task_id: str, task_data: dict[str, Any], worker: Any):
+        raise MemoryError("out of memory")
+
+    result_queue = MagicMock()
+    worker_data = _worker_data_mock(2.0)
+    mock_resource = MagicMock()
+
+    with (
+        patch("cloud_tasks.worker.worker.resource", mock_resource),
+        patch("sys.exit"),
+    ):
+        Worker._worker_process_main(
+            1, oom_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
+        )
+
+    result_queue.put.assert_called_once_with((1, "memory_error", ANY))
+    assert "MemoryError" in result_queue.put.call_args.args[0][2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_on_exception", [True, False])
+async def test_handle_results_memory_error_never_retried(
+    worker: Any, mock_queue: Any, retry_on_exception: bool
+) -> None:
+    """A memory_error result is acknowledged and never retried, even with retry-on-exception."""
+    mock_proc = MagicMock()
+    mock_proc.is_alive.return_value = True
+    mock_proc.pid = 1234
+
+    worker._task_queue = mock_queue
+    worker._running = True
+    worker._data.retry_on_exception = retry_on_exception
+    worker._data.max_memory_allowed_per_task = 2.0
+    worker._event_logger_queue = None
+    worker._event_logger_fp = None
+
+    worker_id = 1
+    task = {"task_id": "task1", "ack_id": "ack1"}
+    worker._processes = {
+        worker_id: {
+            "process": mock_proc,
+            "task": task,
+            "start_time": time.time(),
+        }
+    }
+    worker._result_queue.put((worker_id, "memory_error", "MemoryError traceback"))
+
+    async def stop_when_done() -> None:
+        """Wait for the task to be processed, then stop the worker."""
+        start_time = time.time()
+        while time.time() - start_time < 2.0:
+            if worker._num_tasks_not_retried == 1 or worker._num_tasks_retried == 1:
+                break
+            await asyncio.sleep(0.01)
+        worker._running = False
+
+    handler_task = asyncio.create_task(worker._handle_results())
+    stop_task = asyncio.create_task(stop_when_done())
+    await asyncio.wait_for(asyncio.gather(handler_task, stop_task), timeout=3.0)
+
+    assert worker._num_tasks_not_retried == 1
+    assert worker._num_tasks_retried == 0
+    assert worker._num_tasks_memory_exceeded == 1
+    mock_queue.acknowledge_task.assert_called_once_with("ack1")
+    mock_queue.retry_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_results_memory_error_logs_nonretriable_exception_event(
+    worker: Any, mock_queue: Any
+) -> None:
+    """A memory_error result is logged as a task_exception event with retry False."""
+    from unittest.mock import AsyncMock
+
+    mock_proc = MagicMock()
+    mock_proc.is_alive.return_value = True
+    mock_proc.pid = 1234
+
+    worker._task_queue = mock_queue
+    worker._running = True
+    worker._data.retry_on_exception = True
+    worker._data.max_memory_allowed_per_task = 2.0
+
+    worker_id = 1
+    task = {"task_id": "task1", "ack_id": "ack1"}
+    worker._processes = {
+        worker_id: {
+            "process": mock_proc,
+            "task": task,
+            "start_time": time.time(),
+        }
+    }
+    worker._result_queue.put((worker_id, "memory_error", "MemoryError traceback"))
+
+    with patch.object(worker, "_log_task_exception", new_callable=AsyncMock) as mock_log:
+
+        async def stop_when_done() -> None:
+            """Wait for the task to be processed, then stop the worker."""
+            start_time = time.time()
+            while time.time() - start_time < 2.0:
+                if worker._num_tasks_not_retried == 1:
+                    break
+                await asyncio.sleep(0.01)
+            worker._running = False
+
+        handler_task = asyncio.create_task(worker._handle_results())
+        stop_task = asyncio.create_task(stop_when_done())
+        await asyncio.wait_for(asyncio.gather(handler_task, stop_task), timeout=3.0)
+
+    mock_log.assert_awaited_once_with(
+        "task1", retry=False, elapsed_time=ANY, exception="MemoryError traceback"
+    )

--- a/tests/cloud_tasks/worker/test_worker_memory.py
+++ b/tests/cloud_tasks/worker/test_worker_memory.py
@@ -10,11 +10,11 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
-from cloud_tasks.worker.worker import Worker
+from cloud_tasks.worker.worker import Worker, WorkerData
 
 #: Signature of the callable a Worker is constructed with, as built by the
-#: mock_worker_function fixture: (task_id, task_data, worker) -> (retry, result).
-WorkerFunction = Callable[[str, dict[str, Any], Any], tuple[bool, str]]
+#: mock_worker_function fixture: (task_id, task_data, worker_data) -> (retry, result).
+WorkerFunction = Callable[[str, dict[str, Any], WorkerData], tuple[bool, str]]
 
 
 def test_max_memory_default_no_limit(
@@ -110,7 +110,7 @@ def test_worker_process_main_memory_limit_without_resource_module(
     with (
         patch("cloud_tasks.worker.worker.resource", None),
         patch("sys.exit"),
-        caplog.at_level(logging.WARNING, logger="cloud_tasks.worker.worker"),
+        caplog.at_level(logging.WARNING),
     ):
         Worker._worker_process_main(
             1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
@@ -138,7 +138,7 @@ def test_worker_process_main_setrlimit_failure(
     with (
         patch("cloud_tasks.worker.worker.resource", mock_resource),
         patch("sys.exit"),
-        caplog.at_level(logging.WARNING, logger="cloud_tasks.worker.worker"),
+        caplog.at_level(logging.WARNING),
     ):
         Worker._worker_process_main(
             1, mock_worker_function, worker_data, "test-task", {"key": "value"}, result_queue
@@ -154,7 +154,19 @@ def test_worker_process_main_setrlimit_failure(
 def test_worker_process_main_memory_error(mock_worker_function: WorkerFunction) -> None:
     """A MemoryError from the task is reported as a memory_error result."""
 
-    def oom_worker_function(task_id: str, task_data: dict[str, Any], worker: Any):
+    def oom_worker_function(
+        task_id: str, task_data: dict[str, Any], worker_data: WorkerData
+    ) -> tuple[bool, str]:
+        """Worker function that exhausts the memory limit.
+
+        Parameters:
+            task_id: The ID of the task being run.
+            task_data: The task's payload.
+            worker_data: The worker's configuration.
+
+        Raises:
+            MemoryError: Always, standing in for an allocation past RLIMIT_AS.
+        """
         raise MemoryError("out of memory")
 
     result_queue = MagicMock()
@@ -269,19 +281,34 @@ async def test_handle_results_memory_error_logs_nonretriable_exception_event(
 
 
 @pytest.mark.parametrize("bad_value", ["-1", "0", "nan", "inf"])
+@pytest.mark.parametrize("source", ["args", "env"])
 def test_max_memory_rejects_invalid_values(
-    mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch, bad_value: str
+    mock_worker_function: WorkerFunction,
+    monkeypatch: pytest.MonkeyPatch,
+    bad_value: str,
+    source: str,
 ) -> None:
     """A non-positive or non-finite memory limit is rejected during worker startup.
 
     A worker configured from the command line or the environment doesn't go through the
-    manager's RunConfig validation. Left unchecked, a non-finite value raises while being
-    converted to bytes in every task process, and a negative one is rejected by setrlimit
-    and leaves the task running with no limit at all despite one having been requested.
+    manager's RunConfig validation, so both sources are checked here. Left unchecked, a
+    non-finite value raises while being converted to bytes in every task process, and a
+    negative one is rejected by setrlimit and leaves the task running with no limit at
+    all despite one having been requested.
+
+    Parameters:
+        mock_worker_function: Fixture; the callable the Worker is constructed with.
+        monkeypatch: Pytest fixture used to set the environment and sys.argv.
+        bad_value: The rejected value, as it would be typed or exported.
+        source: Whether the value arrives as a command-line option or an env var.
     """
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
-    monkeypatch.setattr(sys, "argv", ["worker.py", "--max-memory-allowed-per-task", bad_value])
+    if source == "args":
+        monkeypatch.setattr(sys, "argv", ["worker.py", "--max-memory-allowed-per-task", bad_value])
+    else:
+        monkeypatch.setenv("RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK", bad_value)
+        monkeypatch.setattr(sys, "argv", ["worker.py"])
 
     with patch("cloud_tasks.worker.worker.sys.exit", side_effect=SystemExit(1)) as mock_exit:
         with pytest.raises(SystemExit):

--- a/tests/cloud_tasks/worker/test_worker_runtime.py
+++ b/tests/cloud_tasks/worker/test_worker_runtime.py
@@ -232,6 +232,7 @@ async def test_handle_results_process_exception(
 def test_worker_process_main(mock_worker_function):
     result_queue = MagicMock()
     worker_data = MagicMock()
+    worker_data.max_memory_allowed_per_task = None
     task = {
         "task_id": "test-task",
         "data": {"key": "value"},
@@ -1297,6 +1298,7 @@ def test_worker_process_main_with_exception():
 
     result_queue = MagicMock()
     worker_data = MagicMock()
+    worker_data.max_memory_allowed_per_task = None
     worker_data.received_shutdown_request = False
     worker_data.received_termination_notice = False
 
@@ -1324,6 +1326,7 @@ def test_worker_process_main_with_unhandled_exception() -> None:
 
     result_queue = MagicMock()
     worker_data = MagicMock()
+    worker_data.max_memory_allowed_per_task = None
     worker_data.received_shutdown_request = False
     worker_data.received_termination_notice = False
 

--- a/tests/cloud_tasks/worker/test_worker_timeout.py
+++ b/tests/cloud_tasks/worker/test_worker_timeout.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,9 +10,13 @@ import pytest
 
 from cloud_tasks.worker.worker import Worker
 
+#: Signature of the callable a Worker is constructed with, as built by the
+#: mock_worker_function fixture: (task_id, task_data, worker) -> (retry, result).
+WorkerFunction = Callable[[str, dict[str, Any], Any], tuple[bool, str]]
+
 
 @pytest.fixture
-def timeout_worker(mock_worker_function, monkeypatch) -> Worker:
+def timeout_worker(mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch) -> Worker:
     """Worker with one process that has already exceeded max_runtime."""
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")

--- a/tests/cloud_tasks/worker/test_worker_timeout.py
+++ b/tests/cloud_tasks/worker/test_worker_timeout.py
@@ -8,16 +8,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from cloud_tasks.worker.worker import Worker
+from cloud_tasks.worker.worker import Worker, WorkerData
 
 #: Signature of the callable a Worker is constructed with, as built by the
-#: mock_worker_function fixture: (task_id, task_data, worker) -> (retry, result).
-WorkerFunction = Callable[[str, dict[str, Any], Any], tuple[bool, str]]
+#: mock_worker_function fixture: (task_id, task_data, worker_data) -> (retry, result).
+WorkerFunction = Callable[[str, dict[str, Any], WorkerData], tuple[bool, str]]
 
 
 @pytest.fixture
 def timeout_worker(mock_worker_function: WorkerFunction, monkeypatch: pytest.MonkeyPatch) -> Worker:
-    """Worker with one process that has already exceeded max_runtime."""
+    """Worker with one process that has already exceeded max_runtime.
+
+    The worker is marked running with max_runtime set to 10 seconds and a single mock
+    process registered whose start time is 100 seconds in the past, so a single pass of
+    _monitor_process_runtimes sees it as timed out.
+
+    Parameters:
+        mock_worker_function: Fixture; the callable the Worker is constructed with.
+        monkeypatch: Pytest fixture used to set the environment and sys.argv.
+
+    Returns:
+        Worker: A worker whose only tracked process is over its runtime limit.
+    """
     monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
     monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
     monkeypatch.setattr(sys, "argv", ["worker.py"])

--- a/tests/cloud_tasks/worker/test_worker_timeout.py
+++ b/tests/cloud_tasks/worker/test_worker_timeout.py
@@ -1,0 +1,106 @@
+"""Tests for how the worker reports tasks that exceed max_runtime."""
+
+import sys
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloud_tasks.worker.worker import Worker
+
+
+@pytest.fixture
+def timeout_worker(mock_worker_function, monkeypatch) -> Worker:
+    """Worker with one process that has already exceeded max_runtime."""
+    monkeypatch.setenv("RMS_CLOUD_TASKS_PROVIDER", "GCP")
+    monkeypatch.setenv("RMS_CLOUD_TASKS_JOB_ID", "test-job")
+    monkeypatch.setattr(sys, "argv", ["worker.py"])
+    worker = Worker(mock_worker_function)
+    worker._data.max_runtime = 10
+    worker._running = True
+    process = MagicMock()
+    process.pid = 1234
+    process.is_alive.return_value = False
+    worker._processes = {
+        0: {
+            "process": process,
+            "start_time": time.time() - 100,
+            "last_renewal_time": time.time(),
+            "task": {"task_id": "slow-task", "ack_id": "ack-1"},
+        }
+    }
+    return worker
+
+
+async def _run_one_pass(worker: Worker) -> None:
+    """Run _monitor_process_runtimes for a single pass and stop it."""
+
+    async def stop_after_first_sleep(_seconds: float) -> None:
+        worker._running = False
+
+    with patch("cloud_tasks.worker.worker.asyncio.sleep", side_effect=stop_after_first_sleep):
+        await worker._monitor_process_runtimes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_on_timeout", [True, False])
+async def test_timed_out_event_retry_flag_matches_queue_action(
+    timeout_worker: Worker, retry_on_timeout: bool
+) -> None:
+    """The retry flag on a task_timed_out event matches what happens to the message.
+
+    A mismatch is not cosmetic: the task database derives its status from this flag, so
+    reporting retry=False while returning the message to the queue marks a task
+    terminally timed out even though it is about to run again. The manager then counts
+    it as finished and can tear down instances with retries still in flight.
+    """
+    timeout_worker._data.retry_on_timeout = retry_on_timeout
+    events: list[dict[str, Any]] = []
+    timeout_worker._log_event = AsyncMock(side_effect=lambda event, **kw: events.append(event))
+    timeout_worker._queue_retry_task_with_logging = AsyncMock()
+    timeout_worker._queue_acknowledge_task_with_logging = AsyncMock()
+
+    await _run_one_pass(timeout_worker)
+
+    timed_out = [e for e in events if e["event_type"] == "task_timed_out"]
+    assert len(timed_out) == 1
+    assert timed_out[0]["task_id"] == "slow-task"
+    assert timed_out[0]["retry"] is retry_on_timeout
+
+    if retry_on_timeout:
+        timeout_worker._queue_retry_task_with_logging.assert_awaited_once()
+        timeout_worker._queue_acknowledge_task_with_logging.assert_not_awaited()
+    else:
+        timeout_worker._queue_acknowledge_task_with_logging.assert_awaited_once()
+        timeout_worker._queue_retry_task_with_logging.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_task_is_killed_and_untracked(timeout_worker: Worker) -> None:
+    """A timed-out task's process is terminated and dropped from the process table."""
+    timeout_worker._data.retry_on_timeout = False
+    timeout_worker._log_event = AsyncMock()
+    timeout_worker._queue_acknowledge_task_with_logging = AsyncMock()
+    process = timeout_worker._processes[0]["process"]
+
+    await _run_one_pass(timeout_worker)
+
+    process.terminate.assert_called_once()
+    assert timeout_worker._processes == {}
+    assert timeout_worker._num_tasks_timed_out == 1
+
+
+@pytest.mark.asyncio
+async def test_task_within_max_runtime_is_left_alone(timeout_worker: Worker) -> None:
+    """A task that hasn't exceeded max_runtime is not reported or killed."""
+    timeout_worker._processes[0]["start_time"] = time.time()
+    timeout_worker._log_event = AsyncMock()
+    timeout_worker._queue_retry_task_with_logging = AsyncMock()
+    timeout_worker._queue_acknowledge_task_with_logging = AsyncMock()
+
+    await _run_one_pass(timeout_worker)
+
+    timeout_worker._log_event.assert_not_awaited()
+    assert timeout_worker._processes[0]["process"].terminate.call_count == 0
+    assert timeout_worker._num_tasks_timed_out == 0


### PR DESCRIPTION
## Summary

This PR makes long-running cloud jobs reliable in several ways: it fixes two bugs that corrupted task accounting - a GCP Pub/Sub timeout that caused duplicate executions and a retry flag that recorded retrying tasks as finished - gives the task manager a way to detect and replace instances that never start or crash (fixes #49, closes #48), and lets the OS enforce a per-task memory ceiling so runaway tasks fail fast instead of taking down their instance. It also improves what you can see while a job runs: debug output showing the health monitoring make its decisions, and a `--output-file` event log that stays complete across a resume.

### GCP visibility timeout fix (fixes #49)

`GCPPubSubQueue._MAXIMUM_VISIBILITY_TIMEOUT` was 30, but GCP Pub/Sub allows ack deadlines up to 600 seconds. This capped the initial ack deadline at 30s (any task longer than that was redelivered, spawning duplicate executions) and caused every visibility renewal for long-running tasks to be rejected with `InvalidArgument`. The constant is now 600, and `extend_message_visibility` clips requested timeouts to the maximum, making the "will automatically clip" comment in `worker.py` accurate.

`docs/provider_gcp.rst` listed "tasks longer than 600 seconds get retried while still running" under Known Issues, with splitting the task as the only workaround. That was a description of the bug: renewal has always existed but every renewal past 30s was rejected. With the maximum corrected, renewal keeps a task alive for as long as it runs, so that section now describes the real behavior and the case that remains - a worker that stops renewing, whether because it died or because it can't reach Pub/Sub, has its task redelivered.

### Timed-out tasks were recorded as finished while being retried

`_monitor_process_runtimes` logged `task_timed_out` with `retry=False` regardless of `--retry-on-timeout`, then decided a few lines later whether to actually retry. With `--retry-on-timeout` enabled the message went back on the queue for another attempt while the event said it would not be retried.

`update_task_from_event` derives the task status from that flag, so those tasks were recorded as `timed_out` - a terminal state - instead of `timed_out_with_retry`. `get_remaining_task_ids` and `is_all_tasks_complete` both treat terminal states as finished, so the tasks vanished from the remaining count and the run could declare the job complete and terminate instances with retries still in flight. It showed up as a status summary that contradicted itself:

```
  Total tasks: 100
  Heard from: 90
    completed: 48
    timed_out: 42
  Still in original queue: 10
  Remaining tasks: addition-task-000036, addition-task-000037, ...   <- only 10, not 52
```

The flag is now `self._data.retry_on_timeout`, matching what the exception and exit paths already do. Only `--retry-on-timeout` runs were affected, which is why this went unnoticed. The regression test is parametrized over the setting and asserts the event's flag against which queue method was actually called, so the two can't drift apart again.

### Worker keep-alive events and instance health monitoring (closes #48)

Previously, if instances failed to boot or the worker never started, the task manager had no way to notice and instances could run forever.

Workers now send a `keep_alive` event on the cloud-based event queue (never to a local event log file) every `--keepalive-interval` / `RMS_CLOUD_TASKS_KEEPALIVE_INTERVAL` seconds (default 60; 0 disables). Each event includes a timestamp and the instance ID as known to the cloud provider, obtained from the metadata server (GCP instance name, AWS instance-id with IMDSv2, Azure VM name) with hostname fallback.

The manager intercepts these events (not printed, filed, or stored in the DB) and enforces two timeouts, settable in the config or on the `run` command line:

- `--keepalive-startup-timeout` (default 600s): an instance never sends its first keep-alive. If other instances are alive, only that instance is terminated and the scaling loop replaces it. If **no** instance has ever sent a keep-alive and all are overdue, the startup script is presumed broken: all instances are terminated and the job aborts with exit status 1.
- `--keepalive-timeout` (default 300s): an instance stops sending keep-alives; it is presumed crashed and terminated so a replacement can be created.

Timeouts use the manager's clock (immune to clock skew); `--continue` runs give pre-existing instances a fresh startup window. The manager-side `keepalive_interval` and both timeouts live in `RunConfig`, and the interval is exported to workers via the generated startup script.

**Compatibility note:** monitoring is on by default. A manager running this code against workers installed from an older package version (no keep-alive support) will terminate them after the startup timeout; set `--keepalive-startup-timeout 0 --keepalive-timeout 0` or update the worker package to avoid this.

### Instance detail table (debug logging)

With debug logging enabled (`-vv` or more), each scaling check logs a table with one row per instance before the running-instance summary, so it is possible to see which instance the manager considers overdue, and by how much, before it is terminated:

```
Instance details:
  Instance ID              Type            State     Zone           Created              Keep-Alive  Status
  ----------------------------------------------------------------------------------------------------------------------------------
  my-job-1riovtucuu1o1dx9  n2-highcpu-4    running   us-central1-f  2026-08-18T13:47:46  45s ago     OK (255s until overdue)
  my-job-2b77c9e4a1f0d3b8  n2-highcpu-4    starting  us-central1-f  2026-08-18T14:18:00  never       awaiting first keep-alive (120s of 600s)
  my-job-8ad4013f9c22e7a5  n2-standard-16  running   us-central1-b  2026-08-18T13:58:00  never       OVERDUE by 600s for its first keep-alive (limit 600s)
  my-job-c1902e77bb410fa6  n2-highcpu-4    running   us-central1-f  2026-08-18T13:28:00  900s ago    OVERDUE by 600s (limit 300s)
```

Healthy instances show the countdown to overdue rather than just "OK", so trouble is visible before it happens. Columns size themselves to their contents (instance IDs run from 19 characters on AWS to 50+ for generated GCP names) but never shrink below their header width. The keep-alive columns read `not monitored` when this orchestrator isn't the one receiving keep-alive events - both timeouts disabled, `--dry-run`, or the `status` command, which builds an orchestrator only to query instances; without that, `status -vv` would label every healthy worker as never having checked in.

Also fixes the `--verbose` help text, which was off by one: no flag is warning, `-v` is info, `-vv` or more is debug.

### Complete event log across a resume

`--output-file` opens its file for append, so resuming with `--continue` extends the existing log. But if the file didn't exist yet - because the earlier part of the job ran without `--output-file`, or the file was moved away - the log covered only the part of the job the new process observed, even though the database held the whole history.

A `--continue` run now writes the stored events to a newly created output file before monitoring resumes. Events are streamed from the database rather than materialized (a long job accumulates tens of thousands), and the stored `raw_event` is the same JSON the live path writes, so backfilled and live lines are indistinguishable.

An output file that already exists is never re-seeded - its contents are presumed to already cover those events, and otherwise every resume would duplicate the entire history. A failed backfill is logged but does not abort: the job may already be running, so losing the historical part of the log beats refusing to monitor it.

Review of this change surfaced a pre-existing data-integrity bug alongside it. The write to the optional output file happened before `insert_event`/`update_task_from_event` and shared their `try` block, so a full disk silently skipped every database update - the authoritative record - while the run appeared healthy. The database is now updated first, and an output-file write, flush, or backfill error closes and drops the stream, logs why, and lets monitoring continue. A failure to *read* the stored events is reported separately and leaves the file open, since a database problem says nothing about the file. `monitor_event_queue` seeds unconditionally, since it errors out unless the database already exists and so only ever attaches to a job already under way. Keep-alive events are never stored in the database and so never appear in the log.

### Per-task memory limit

`--max-memory-allowed-per-task` (GB) on both the worker and the `run` command (also settable in the config file and via `RMS_CLOUD_TASKS_MAX_MEMORY_ALLOWED_PER_TASK`, which the generated startup script exports when configured). Each task process applies an address-space limit (`RLIMIT_AS`) on itself before the task runs, so the OS enforces the ceiling with no run-time monitoring. A task that exceeds the limit gets a `MemoryError`, reported as a **non-retriable** failure: the task is acknowledged (never retried, regardless of `--retry-on-exception`) and logged as a `task_exception` event with `retry: false`, mapping to the existing `exception` status in the task database. Default is no limit; on platforms without the POSIX `resource` module (Windows) the limit is skipped with a warning. A non-positive or non-finite value is rejected at worker startup: a worker configured from the command line or the environment skips the manager's `RunConfig` validation, and left unchecked a non-finite value raised while being converted to bytes in every task process while a negative one was rejected by `setrlimit`, leaving the task with no limit despite one having been requested.

Documented caveats: the limit applies to virtual address space rather than resident memory (set it with headroom); C-level allocation failures may crash the process instead of raising, surfacing as `task_exited` governed by `--retry-on-exit`; subprocesses spawned by a task each get the same individual limit rather than a shared one.

## Testing

- 73 new tests: GCP visibility clipping, worker keep-alive sending and identity lookup, EventMonitor interception, orchestrator timeout/abort logic, rlimit application and MemoryError handling (with mocked `resource` so the test process is never limited), non-retriable result handling, startup-script exports, config validation, instance-table rendering (column alignment under long and short IDs, every keep-alive state, and the not-monitored cases), event-log backfill (new vs. existing file, backfill disabled, live events appending to the backfill, and a failed backfill leaving the monitor usable), timeout reporting (retry flag against queue action under both settings, process termination, and a task still inside max_runtime), memory-limit validation, and output-file I/O failures (a broken stream is dropped and the database still updated; a failing stream and a failing database during backfill are distinguished)
- OS enforcement verified end-to-end in a subprocess (0.5 GB `RLIMIT_AS` → 1 GB allocation raises `MemoryError`)
- Backfill verified end to end: a database with two recorded events plus one arriving live produced all three in order; re-running with the file present left it unchanged
- The timeout fix was verified by reintroducing the hardcoded flag and confirming the new test fails
- Full suite: 550 passed, 1 skipped; mypy and ruff clean

### Test isolation fix

A `Worker` created with a `task_source` defaults to logging events to a file, and the default event log file name (`events.log`) is relative, so tests that start such a worker appended to whatever directory pytest was invoked from - normally the top of the repository. Two tests that deliberately raise from their task source did this on every run, and `.gitignore`'s `*.log` kept the growing file out of `git status`. Worker tests now run in their own `tmp_path`. Forcing `RMS_CLOUD_TASKS_EVENT_LOG_TO_FILE=false` would have been more direct, but several tests assert the default value of that setting, so `chdir` is used to leave the behavior under test unchanged and only relocate where the file lands. Verified by snapshotting the repo before and after a full run: no files are created or modified in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable per-task memory limits with clear handling for memory-exceeded tasks.
  - Added worker keep-alive monitoring, startup checks, timeout detection, and instance status reporting.
  - Added CLI and configuration options for memory and keep-alive settings.
  - Event logs now append safely and can be restored when resuming runs with a new output file.

- **Bug Fixes**
  - Improved cloud message visibility-timeout handling up to 600 seconds.
  - Jobs now terminate or abort appropriately when workers stop reporting health.

- **Documentation**
  - Documented memory limits, keep-alive settings, event-log behavior, defaults, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



