### PR TITLE
Add per-cpu and per-task boot disk IOPS and throughput options

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -129,7 +129,11 @@ in the configuration file (see :ref:`config_compute_instance_options`).
 --boot-disk-per-task N        The amount of boot disk per task
 --boot-disk-types TYPES       The types of boot disks to use
 --boot-disk-iops N            The number of provisioned IOPS for the boot disk, if applicable
+--boot-disk-iops-per-cpu N    The number of provisioned IOPS for the boot disk per vCPU
+--boot-disk-iops-per-task N   The number of provisioned IOPS for the boot disk per task
 --boot-disk-throughput N      The number of provisioned throughput in MB/s for the boot disk, if applicable
+--boot-disk-throughput-per-cpu N   The provisioned throughput in MB/s for the boot disk per vCPU
+--boot-disk-throughput-per-task N  The provisioned throughput in MB/s for the boot disk per task
 
 
 .. _cli_number_of_instances_options:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -196,10 +196,20 @@ The boot disk type is provider-specific and can be a single type or a list of ty
 Finally, some boot disk types require additional configuration:
 
 * ``boot_disk_iops``: For any boot disk type that supports it, the number of provisioned IOPS
-  to request; this is an absolute value and is not scaled by the number of vCPUs or tasks
+  to request; this is an absolute value
+* ``boot_disk_iops_per_cpu``: The number of provisioned IOPS to request per vCPU (defaults to 0)
+* ``boot_disk_iops_per_task``: The number of provisioned IOPS to request per task (defaults to 0)
 * ``boot_disk_throughput``: For any boot disk type that supports it, the number of provisioned
-  throughput in MB/s to request; this is an absolute value and is not scaled by the number of
-  vCPUs or tasks
+  throughput in MB/s to request; this is an absolute value
+* ``boot_disk_throughput_per_cpu``: The provisioned throughput in MB/s to request per vCPU
+  (defaults to 0)
+* ``boot_disk_throughput_per_task``: The provisioned throughput in MB/s to request per task
+  (defaults to 0)
+
+As with the boot disk size, if more than one value is specified the maximum of the values
+will be used, and the number of tasks per instance is derived from ``cpus_per_task``. The
+result is rounded up to a whole number of IOPS or MB/s. If no per-vCPU or per-task value is
+specified, the absolute value (or the provider default) is used unchanged.
 
 
 .. _config_number_of_instances_options:

--- a/docs/provider_gcp.rst
+++ b/docs/provider_gcp.rst
@@ -220,6 +220,11 @@ number of provisioned IOPS, and also requires the specification of the amount of
 provisioned throughput in MB/s using the ``boot_disk_throughput`` configuration option. If
 not specified, the default amount of throughput (170 MB/s) will be used.
 
+Both amounts can also be scaled by the size of the selected instance using the
+``boot_disk_iops_per_cpu``, ``boot_disk_iops_per_task``, ``boot_disk_throughput_per_cpu``,
+and ``boot_disk_throughput_per_task`` configuration options. When more than one of these is
+given, the largest resulting amount is used, so the absolute option acts as a floor.
+
 Note that different instances and boot disk types have different limits on the number of IOPS
 and the amount of throughput, and also the minimum and maximum disk size. These limits are
 not enforced in the Cloud Tasks system and it is your responsibility to ensure that what

--- a/src/cloud_tasks/cli.py
+++ b/src/cloud_tasks/cli.py
@@ -2424,9 +2424,29 @@ def add_instance_args(parser: argparse.ArgumentParser) -> None:
         help="Specify the boot disk provisioned IOPS (GCP only)",
     )
     parser.add_argument(
+        "--boot-disk-iops-per-cpu",
+        type=float,
+        help="Specify the boot disk provisioned IOPS per vCPU (GCP only)",
+    )
+    parser.add_argument(
+        "--boot-disk-iops-per-task",
+        type=float,
+        help="Specify the boot disk provisioned IOPS per task (GCP only)",
+    )
+    parser.add_argument(
         "--boot-disk-throughput",
         type=int,
         help="Specify the boot disk provisioned throughput (GCP only)",
+    )
+    parser.add_argument(
+        "--boot-disk-throughput-per-cpu",
+        type=float,
+        help="Specify the boot disk provisioned throughput per vCPU (GCP only)",
+    )
+    parser.add_argument(
+        "--boot-disk-throughput-per-task",
+        type=float,
+        help="Specify the boot disk provisioned throughput per task (GCP only)",
     )
     parser.add_argument(
         "--total-boot-disk-size",

--- a/src/cloud_tasks/common/config.py
+++ b/src/cloud_tasks/common/config.py
@@ -193,7 +193,11 @@ class RunConfig(BaseModel, validate_assignment=True):
 
     boot_disk_types: list[str] | str | None = None
     boot_disk_iops: PositiveInt | None = None  # GCP only
+    boot_disk_iops_per_cpu: NonNegativeFloat | None = None  # GCP only
+    boot_disk_iops_per_task: NonNegativeFloat | None = None  # GCP only
     boot_disk_throughput: PositiveInt | None = None  # GCP only
+    boot_disk_throughput_per_cpu: NonNegativeFloat | None = None  # GCP only
+    boot_disk_throughput_per_task: NonNegativeFloat | None = None  # GCP only
     total_boot_disk_size: PositiveFloat | None = None
     boot_disk_base_size: NonNegativeFloat | None = None
     boot_disk_per_cpu: NonNegativeFloat | None = None

--- a/src/cloud_tasks/instance_manager/gcp.py
+++ b/src/cloud_tasks/instance_manager/gcp.py
@@ -390,6 +390,12 @@ class GCPComputeInstanceManager(InstanceManager):
                     "boot_disk_base_size": Base amount of boot disk storage in GB
                     "boot_disk_per_cpu": Amount of boot disk storage per vCPU
                     "boot_disk_per_task": Amount of boot disk storage per task
+                    "boot_disk_iops": Absolute number of provisioned boot disk IOPS
+                    "boot_disk_iops_per_cpu": Provisioned boot disk IOPS per vCPU
+                    "boot_disk_iops_per_task": Provisioned boot disk IOPS per task
+                    "boot_disk_throughput": Absolute provisioned boot disk throughput in MB/s
+                    "boot_disk_throughput_per_cpu": Provisioned boot disk throughput per vCPU
+                    "boot_disk_throughput_per_task": Provisioned boot disk throughput per task
                     "use_spot": Whether to filter for spot-capable instance types
 
         Returns:
@@ -467,12 +473,6 @@ class GCPComputeInstanceManager(InstanceManager):
                 )
                 continue
 
-            boot_disk_iops = constraints.get("boot_disk_iops")
-            if boot_disk_iops is None:
-                boot_disk_iops = self._DEFAULT_BOOT_DISK_IOPS
-            boot_disk_throughput = constraints.get("boot_disk_throughput")
-            if boot_disk_throughput is None:
-                boot_disk_throughput = self._DEFAULT_BOOT_DISK_THROUGHPUT
             if machine_type_family in self._MACHINE_TYPE_FAMILY_TO_DISK_TYPES:
                 supported_boot_disk_types = self._MACHINE_TYPE_FAMILY_TO_DISK_TYPES[
                     machine_type_family
@@ -508,8 +508,8 @@ class GCPComputeInstanceManager(InstanceManager):
                 "boot_disk_gb": 0,  # Will fill in later
                 "supported_boot_disk_types": supported_boot_disk_types,
                 "available_boot_disk_types": available_boot_disk_types,
-                "boot_disk_iops": boot_disk_iops,
-                "boot_disk_throughput": boot_disk_throughput,
+                "boot_disk_iops": 0,  # Will fill in later
+                "boot_disk_throughput": 0,  # Will fill in later
                 "supports_spot": True,  # There is no other informationa available
                 "description": machine_type.description,
                 # https://www.googleapis.com/compute/v1/projects/[project]/zones/
@@ -519,6 +519,23 @@ class GCPComputeInstanceManager(InstanceManager):
 
             boot_disk_gb = self._get_boot_disk_size(instance_info, constraints)
             instance_info["boot_disk_gb"] = boot_disk_gb
+
+            instance_info["boot_disk_iops"] = self._get_boot_disk_provisioned_amount(
+                instance_info,
+                constraints,
+                absolute_key="boot_disk_iops",
+                per_cpu_key="boot_disk_iops_per_cpu",
+                per_task_key="boot_disk_iops_per_task",
+                default=self._DEFAULT_BOOT_DISK_IOPS,
+            )
+            instance_info["boot_disk_throughput"] = self._get_boot_disk_provisioned_amount(
+                instance_info,
+                constraints,
+                absolute_key="boot_disk_throughput",
+                per_cpu_key="boot_disk_throughput_per_cpu",
+                per_task_key="boot_disk_throughput_per_task",
+                default=self._DEFAULT_BOOT_DISK_THROUGHPUT,
+            )
 
             if self._instance_matches_constraints(instance_info, constraints):
                 instance_types[machine_type.name] = instance_info
@@ -1305,6 +1322,12 @@ class GCPComputeInstanceManager(InstanceManager):
                     "boot_disk_base_size": Base amount of boot disk storage in GB
                     "boot_disk_per_cpu": Amount of boot disk storage per vCPU
                     "boot_disk_per_task": Amount of boot disk storage per task
+                    "boot_disk_iops": Absolute number of provisioned boot disk IOPS
+                    "boot_disk_iops_per_cpu": Provisioned boot disk IOPS per vCPU
+                    "boot_disk_iops_per_task": Provisioned boot disk IOPS per task
+                    "boot_disk_throughput": Absolute provisioned boot disk throughput in MB/s
+                    "boot_disk_throughput_per_cpu": Provisioned boot disk throughput per vCPU
+                    "boot_disk_throughput_per_task": Provisioned boot disk throughput per task
                     "use_spot": Whether to filter for spot-capable instance types
 
         Returns:

--- a/src/cloud_tasks/instance_manager/instance_manager.py
+++ b/src/cloud_tasks/instance_manager/instance_manager.py
@@ -1,3 +1,4 @@
+import math
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -256,6 +257,62 @@ class InstanceManager(ABC):
         boot_disk_from_tasks = boot_disk_base_size + boot_disk_per_task * tasks_per_instance
 
         return max(boot_disk, boot_disk_from_cpus, boot_disk_from_tasks)
+
+    def _get_boot_disk_provisioned_amount(
+        self,
+        instance_info: dict[str, Any],
+        boot_disk_constraints: dict[str, Any],
+        *,
+        absolute_key: str,
+        per_cpu_key: str,
+        per_task_key: str,
+        default: int,
+    ) -> int:
+        """Compute a provisioned boot disk amount (IOPS or throughput) for an instance.
+
+        The absolute constraint named by absolute_key acts as a floor and defaults to
+        default if missing. Missing per_cpu_key and per_task_key constraints are treated
+        as 0. cpus_per_task defaults to 1. Formula: amount_from_cpus = per_cpu *
+        num_cpus; amount_from_tasks = per_task * tasks_per_instance. The returned amount
+        is max(absolute, amount_from_cpus, amount_from_tasks), rounded up to the next
+        whole unit because providers only accept integral IOPS and throughput. When
+        neither per-CPU nor per-task scaling is configured the absolute value (or
+        default) is returned unchanged.
+
+        Parameters:
+            instance_info: dict[str, Any] – instance attributes; "vcpu" is used for
+                per-cpu/per-task scaling.
+            boot_disk_constraints: dict[str, Any] – keys read: the key named by
+                absolute_key (numeric, default default), the keys named by per_cpu_key
+                and per_task_key (numeric, default 0), cpus_per_task (int, default 1).
+            absolute_key: str – constraint name holding the absolute amount.
+            per_cpu_key: str – constraint name holding the amount per vCPU.
+            per_task_key: str – constraint name holding the amount per task.
+            default: int – amount to use when the absolute constraint is missing.
+
+        Returns:
+            int: Computed amount, at least the absolute value (or default). No exception
+            is raised for missing keys.
+        """
+        absolute = boot_disk_constraints.get(absolute_key)
+        if absolute is None:
+            absolute = default
+        per_cpu = boot_disk_constraints.get(per_cpu_key)
+        if per_cpu is None:
+            per_cpu = 0
+        per_task = boot_disk_constraints.get(per_task_key)
+        if per_task is None:
+            per_task = 0
+        num_cpus = instance_info["vcpu"]
+        cpus_per_task = boot_disk_constraints.get("cpus_per_task")
+        if cpus_per_task is None:
+            cpus_per_task = 1
+        tasks_per_instance = num_cpus // cpus_per_task
+
+        amount_from_cpus = per_cpu * num_cpus
+        amount_from_tasks = per_task * tasks_per_instance
+
+        return math.ceil(max(absolute, amount_from_cpus, amount_from_tasks))
 
     @abstractmethod
     async def get_available_instance_types(

--- a/src/cloud_tasks/instance_manager/orchestrator.py
+++ b/src/cloud_tasks/instance_manager/orchestrator.py
@@ -328,7 +328,12 @@ export RMS_CLOUD_TASKS_RETRY_ON_EXCEPTION={self._run_config.retry_on_exception}
             # selected in the config.
             boot_disk_constraints = {
                 "boot_disk_iops": self._run_config.boot_disk_iops,
+                "boot_disk_iops_per_cpu": self._run_config.boot_disk_iops_per_cpu,
+                "boot_disk_iops_per_task": self._run_config.boot_disk_iops_per_task,
                 "boot_disk_throughput": self._run_config.boot_disk_throughput,
+                "boot_disk_throughput_per_cpu": self._run_config.boot_disk_throughput_per_cpu,
+                "boot_disk_throughput_per_task": self._run_config.boot_disk_throughput_per_task,
+                "cpus_per_task": self._run_config.cpus_per_task,
             }
             use_spot = self._run_config.use_spot if self._run_config.use_spot is not None else False
             result = await self._instance_manager.get_instance_pricing(

--- a/tests/cloud_tasks/common/test_config.py
+++ b/tests/cloud_tasks/common/test_config.py
@@ -139,6 +139,36 @@ def test_runconfig_instance_types_list_or_str():
     RunConfig(instance_types="foo")
 
 
+def test_runconfig_boot_disk_iops_and_throughput_per_cpu_and_task():
+    rc = RunConfig(
+        boot_disk_iops_per_cpu=100,
+        boot_disk_iops_per_task=200,
+        boot_disk_throughput_per_cpu=10,
+        boot_disk_throughput_per_task=20,
+    )
+    assert rc.boot_disk_iops_per_cpu == 100
+    assert rc.boot_disk_iops_per_task == 200
+    assert rc.boot_disk_throughput_per_cpu == 10
+    assert rc.boot_disk_throughput_per_task == 20
+
+    # They are optional, like the absolute versions
+    rc = RunConfig()
+    assert rc.boot_disk_iops_per_cpu is None
+    assert rc.boot_disk_iops_per_task is None
+    assert rc.boot_disk_throughput_per_cpu is None
+    assert rc.boot_disk_throughput_per_task is None
+
+    # Negative values are rejected
+    for field in (
+        "boot_disk_iops_per_cpu",
+        "boot_disk_iops_per_task",
+        "boot_disk_throughput_per_cpu",
+        "boot_disk_throughput_per_task",
+    ):
+        with pytest.raises(ValueError):
+            RunConfig(**{field: -1})
+
+
 def test_runconfig_architecture_case():
     rc = RunConfig(architecture="x86_64")
     assert rc.architecture == "x86_64"

--- a/tests/cloud_tasks/instance_manager/gcp/test_gcp_instance_types.py
+++ b/tests/cloud_tasks/instance_manager/gcp/test_gcp_instance_types.py
@@ -266,3 +266,83 @@ async def test_get_available_instance_types_with_memory_per_cpu_constraints(
     assert len(result) == 1
     assert "n1-standard-2" in result
     assert "n2-standard-4-lssd" not in result  # Has 4 GB/CPU
+
+
+@pytest.mark.asyncio
+async def test_get_available_instance_types_with_boot_disk_iops_per_cpu(
+    gcp_instance_manager_n1_n2: GCPComputeInstanceManager,
+) -> None:
+    """Test scaling the provisioned boot disk IOPS and throughput by the number of vCPUs."""
+    gcp_instance_manager_n1_n2 = deepcopy_gcp_instance_manager(gcp_instance_manager_n1_n2)
+
+    # Arrange
+    constraints = {
+        "boot_disk_iops_per_cpu": 2000,
+        "boot_disk_throughput_per_cpu": 100,
+    }
+
+    # Act
+    result = await gcp_instance_manager_n1_n2.get_available_instance_types(constraints)
+
+    # Assert
+    assert len(result) == 2
+    # n1-standard-2 has 2 vCPUs
+    assert result["n1-standard-2"]["boot_disk_iops"] == 4000
+    assert result["n1-standard-2"]["boot_disk_throughput"] == 200
+    # n2-standard-4-lssd has 4 vCPUs
+    assert result["n2-standard-4-lssd"]["boot_disk_iops"] == 8000
+    assert result["n2-standard-4-lssd"]["boot_disk_throughput"] == 400
+
+
+@pytest.mark.asyncio
+async def test_get_available_instance_types_with_boot_disk_iops_per_task(
+    gcp_instance_manager_n1_n2: GCPComputeInstanceManager,
+) -> None:
+    """Test scaling the provisioned boot disk IOPS and throughput by the number of tasks."""
+    gcp_instance_manager_n1_n2 = deepcopy_gcp_instance_manager(gcp_instance_manager_n1_n2)
+
+    # Arrange
+    constraints = {
+        "cpus_per_task": 2,
+        "boot_disk_iops_per_task": 2000,
+        "boot_disk_throughput_per_task": 100,
+    }
+
+    # Act
+    result = await gcp_instance_manager_n1_n2.get_available_instance_types(constraints)
+
+    # Assert
+    assert len(result) == 2
+    # n1-standard-2 has 2 vCPUs, so one task; the provider defaults are larger
+    assert result["n1-standard-2"]["boot_disk_iops"] == 3120
+    assert result["n1-standard-2"]["boot_disk_throughput"] == 170
+    # n2-standard-4-lssd has 4 vCPUs, so two tasks
+    assert result["n2-standard-4-lssd"]["boot_disk_iops"] == 4000
+    assert result["n2-standard-4-lssd"]["boot_disk_throughput"] == 200
+
+
+@pytest.mark.asyncio
+async def test_get_available_instance_types_with_absolute_boot_disk_iops(
+    gcp_instance_manager_n1_n2: GCPComputeInstanceManager,
+) -> None:
+    """Test that an absolute boot disk IOPS value is a floor for the scaled values."""
+    gcp_instance_manager_n1_n2 = deepcopy_gcp_instance_manager(gcp_instance_manager_n1_n2)
+
+    # Arrange
+    constraints = {
+        "boot_disk_iops": 10000,
+        "boot_disk_iops_per_cpu": 2000,
+        "boot_disk_throughput": 500,
+        "boot_disk_throughput_per_cpu": 100,
+    }
+
+    # Act
+    result = await gcp_instance_manager_n1_n2.get_available_instance_types(constraints)
+
+    # Assert
+    assert len(result) == 2
+    # Both instances are too small for the per-CPU values to reach the absolute values
+    assert result["n1-standard-2"]["boot_disk_iops"] == 10000
+    assert result["n1-standard-2"]["boot_disk_throughput"] == 500
+    assert result["n2-standard-4-lssd"]["boot_disk_iops"] == 10000
+    assert result["n2-standard-4-lssd"]["boot_disk_throughput"] == 500

--- a/tests/cloud_tasks/instance_manager/test_instance_manager.py
+++ b/tests/cloud_tasks/instance_manager/test_instance_manager.py
@@ -367,3 +367,153 @@ class TestInstanceManager:
                 "max_cpu": 6,  # Irrelevant as min_tasks already exceeds instance CPUs
             },
         )
+
+    def _iops(
+        self,
+        instance_manager: InstanceManager,
+        instance_info: dict,
+        constraints: dict,
+        default: int = 3120,
+    ) -> int:
+        """Compute the provisioned boot disk IOPS for the given constraints."""
+        return instance_manager._get_boot_disk_provisioned_amount(
+            instance_info,
+            constraints,
+            absolute_key="boot_disk_iops",
+            per_cpu_key="boot_disk_iops_per_cpu",
+            per_task_key="boot_disk_iops_per_task",
+            default=default,
+        )
+
+    def test_get_boot_disk_provisioned_amount_defaults(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """With no constraints at all the provider default is used."""
+        assert self._iops(instance_manager, base_instance_info, {}) == 3120
+
+    def test_get_boot_disk_provisioned_amount_absolute_only(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """An absolute value is used unchanged when no scaling is requested."""
+        assert self._iops(instance_manager, base_instance_info, {"boot_disk_iops": 5000}) == 5000
+
+        # Explicit Nones are treated the same as missing keys
+        assert (
+            self._iops(
+                instance_manager,
+                base_instance_info,
+                {
+                    "boot_disk_iops": 5000,
+                    "boot_disk_iops_per_cpu": None,
+                    "boot_disk_iops_per_task": None,
+                    "cpus_per_task": None,
+                },
+            )
+            == 5000
+        )
+
+    def test_get_boot_disk_provisioned_amount_per_cpu(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """The per-vCPU value is multiplied by the number of vCPUs."""
+        # 4 vCPUs * 1000 = 4000, which exceeds the 3120 default
+        assert (
+            self._iops(instance_manager, base_instance_info, {"boot_disk_iops_per_cpu": 1000})
+            == 4000
+        )
+
+        # The absolute value acts as a floor, as it does for boot disk size
+        assert (
+            self._iops(
+                instance_manager,
+                base_instance_info,
+                {"boot_disk_iops": 10000, "boot_disk_iops_per_cpu": 1000},
+            )
+            == 10000
+        )
+
+    def test_get_boot_disk_provisioned_amount_per_task(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """The per-task value is multiplied by the number of tasks per instance."""
+        # 4 vCPUs // 2 CPUs per task = 2 tasks; 2 * 4000 = 8000
+        assert (
+            self._iops(
+                instance_manager,
+                base_instance_info,
+                {"boot_disk_iops_per_task": 4000, "cpus_per_task": 2},
+            )
+            == 8000
+        )
+
+        # cpus_per_task defaults to 1, giving one task per vCPU
+        assert (
+            self._iops(instance_manager, base_instance_info, {"boot_disk_iops_per_task": 4000})
+            == 16000
+        )
+
+    def test_get_boot_disk_provisioned_amount_takes_maximum(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """When several values are given the largest one wins."""
+        assert (
+            self._iops(
+                instance_manager,
+                base_instance_info,
+                {
+                    "boot_disk_iops": 4500,
+                    "boot_disk_iops_per_cpu": 1000,  # 4000
+                    "boot_disk_iops_per_task": 2000,  # 2 tasks -> 4000
+                    "cpus_per_task": 2,
+                },
+            )
+            == 4500
+        )
+        assert (
+            self._iops(
+                instance_manager,
+                base_instance_info,
+                {
+                    "boot_disk_iops": 4500,
+                    "boot_disk_iops_per_cpu": 1000,  # 4000
+                    "boot_disk_iops_per_task": 3000,  # 2 tasks -> 6000
+                    "cpus_per_task": 2,
+                },
+            )
+            == 6000
+        )
+
+    def test_get_boot_disk_provisioned_amount_rounds_up(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """Fractional amounts are rounded up to a whole unit."""
+        # 4 vCPUs * 12.5 = 50.0 exactly
+        assert (
+            self._iops(
+                instance_manager, base_instance_info, {"boot_disk_iops_per_cpu": 12.5}, default=0
+            )
+            == 50
+        )
+        # 4 vCPUs * 12.6 = 50.4, rounded up so the disk is never under-provisioned
+        assert (
+            self._iops(
+                instance_manager, base_instance_info, {"boot_disk_iops_per_cpu": 12.6}, default=0
+            )
+            == 51
+        )
+
+    def test_get_boot_disk_provisioned_amount_throughput_keys(
+        self, instance_manager: InstanceManager, base_instance_info: dict
+    ) -> None:
+        """The same helper drives throughput using its own constraint names."""
+        assert (
+            instance_manager._get_boot_disk_provisioned_amount(
+                base_instance_info,
+                {"boot_disk_throughput_per_cpu": 100},
+                absolute_key="boot_disk_throughput",
+                per_cpu_key="boot_disk_throughput_per_cpu",
+                per_task_key="boot_disk_throughput_per_task",
+                default=170,
+            )
+            == 400
+        )


### PR DESCRIPTION
This PR proposes adding per-CPU and per-task versions of the `boot_disk_iops` and `boot_disk_throughput` options (Fixes #8). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/359. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

Issue #8 notes that `boot_disk_iops` and `boot_disk_throughput` are absolute values, while many other parameters also have per-CPU and per-task forms. `docs/config.rst` documented that limitation directly: "this is an absolute value and is not scaled by the number of vCPUs or tasks". The practical effect is that one configuration cannot provision proportional disk performance across instance types of different sizes — a value that suits a 2-vCPU instance starves a 32-vCPU one, and a value sized for the large instance overprovisions every small one.

Reproduced on `main` at 482c093:

```
$ python -c "from cloud_tasks.common.config import RunConfig; RunConfig(boot_disk_iops_per_cpu=2000)"
pydantic_core._pydantic_core.ValidationError: 1 validation error for RunConfig
boot_disk_iops_per_cpu
  Extra inputs are not permitted [type=extra_forbidden, input_value=2000, input_type=int]

$ cloud_tasks run --help | grep -c boot-disk-iops-per-cpu
0
```

This adds `boot_disk_iops_per_cpu`, `boot_disk_iops_per_task`, `boot_disk_throughput_per_cpu`, and `boot_disk_throughput_per_task` to `RunConfig`, with the matching command line options, following the shape of the existing `boot_disk_per_cpu` and `boot_disk_per_task` size options. The arithmetic lives in a new `InstanceManager._get_boot_disk_provisioned_amount()` alongside `_get_boot_disk_size()` and mirrors it: the amount is the maximum of the absolute value, the per-vCPU value times the number of vCPUs, and the per-task value times `vcpu // cpus_per_task`, so the absolute option now acts as a floor. The result is rounded up, so a disk is never provisioned below what was asked for. `GCPComputeInstanceManager.get_available_instance_types()` resolves both amounts per instance type at the point where it already computes the boot disk size, so the scaled values flow through instance pricing, optimal instance type selection, and `start_instance()` with no further changes.

On backward compatibility: with no per-vCPU or per-task option set, each value collapses to `max(absolute_or_default, 0, 0)`, which is exactly the previous result. No existing option changes meaning and nothing is removed — the existing assertions that an unconstrained instance reports 3120 IOPS and 170 MB/s still hold unchanged.

Verification, on Python 3.12:

```
$ python -m pytest -q       # before: 475 passed, 1 skipped
$ python -m pytest -q       # after:  486 passed, 1 skipped
$ ruff check src tests      # All checks passed!  (before and after)
$ mypy src                  # Success: no issues found in 22 source files  (before and after)
```

The 11 added tests cover the new arithmetic (provider defaults, absolute only, per-CPU, per-task, the maximum of several at once, rounding up, and the throughput option names), the end-to-end result from `get_available_instance_types()` for both fixture instance types, and config validation including rejection of negative values. To confirm they really do pin the new behavior, reverting only `src/cloud_tasks/instance_manager/gcp.py` to its current state on `main` and re-running turns the two scaling tests red (`assert 3120 == 4000`) while the absolute-value and config tests stay green.

Documentation is updated in `docs/config.rst`, `docs/cli.rst`, and `docs/provider_gcp.rst`.

One merge note: #51 is open and also touches `common/config.py`, `cli.py`, and `instance_manager/orchestrator.py`, for `max_memory_allowed_per_task`. The edits here are in different parts of those files, but whichever lands second may want a small rebase.

## How this was managed

We imported this repository's issues and pull requests into a live agile board and tracked this work on it: [issue #8 as a story](https://eastagiletracker.com/projects/359/stories/219405) on the [project board](https://eastagiletracker.com/projects/359), which holds 45 stories imported from here.

![board](https://raw.githubusercontent.com/eastagiletracker/rms-cloud-tasks/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
