### PR TITLE
fix: apply ack deadline to pre-existing GCP subscription

### DIFF
--- a/src/cloud_tasks/queue_manager/gcp.py
+++ b/src/cloud_tasks/queue_manager/gcp.py
@@ -176,6 +176,9 @@ class GCPPubSubQueue(QueueManager):
 
         # Check if subscription exists
         self._subscription_exists = False
+        # True once the subscription's ack deadline is known to match
+        # self._visibility_timeout (set on create or after update_subscription)
+        self._ack_deadline_applied = False
         try:
             self._subscriber.get_subscription(request={"subscription": self._subscription_path})
             self._logger.debug(f'Subscription "{self._subscription_name}" already exists')
@@ -239,9 +242,40 @@ class GCPPubSubQueue(QueueManager):
 
         self._topic_exists = False
 
+    async def _update_ack_deadline(self) -> None:
+        """Apply self._visibility_timeout to a pre-existing subscription (at most once).
+
+        A subscription created by another process (e.g. the job dispatcher) may have a
+        different ack deadline than this instance requested; without this update, messages
+        pulled by a long-running worker would expire and be redelivered while still being
+        processed. No-op if no visibility timeout was requested or it was already applied.
+        """
+        if self._visibility_timeout is None or self._ack_deadline_applied:
+            return
+
+        loop = asyncio.get_event_loop()
+        self._logger.info(
+            f'Updating subscription "{self._subscription_name}" ack deadline to '
+            f"{self._visibility_timeout} seconds"
+        )
+        await loop.run_in_executor(
+            None,
+            lambda: self._subscriber.update_subscription(
+                request={
+                    "subscription": {
+                        "name": self._subscription_path,
+                        "ack_deadline_seconds": self._visibility_timeout,
+                    },
+                    "update_mask": {"paths": ["ack_deadline_seconds"]},
+                }
+            ),
+        )
+        self._ack_deadline_applied = True
+
     async def _create_subscription(self) -> None:
         """Create the Pub/Sub subscription if it doesn't exist."""
         if self._subscription_exists:
+            await self._update_ack_deadline()
             return
 
         try:
@@ -269,18 +303,12 @@ class GCPPubSubQueue(QueueManager):
             time.sleep(2)
             self._logger.info(f'Subscription "{self._subscription_name}" created successfully')
             self._subscription_exists = True
+            self._ack_deadline_applied = True
         except gcp_exceptions.AlreadyExists:
-            # Modify an existing subscription to change the ack deadline to visibility_timeout
+            # Created by another process; update its ack deadline to visibility_timeout
             self._logger.info(f'Subscription "{self._subscription_name}" already exists...')
-            if self._visibility_timeout is not None:
-                self._logger.info(f"Updating visibility timeout to {visibility_timeout} seconds")
-                self._subscriber.modify_subscription(
-                    request={
-                        "subscription": self._subscription_path,
-                        "ack_deadline_seconds": visibility_timeout,
-                    }
-                )
             self._subscription_exists = True
+            await self._update_ack_deadline()
         except Exception:
             raise
 

--- a/src/cloud_tasks/worker/worker.py
+++ b/src/cloud_tasks/worker/worker.py
@@ -1676,15 +1676,19 @@ class Worker:
 
     async def _visibility_renewal_worker(self) -> None:
         """Background worker that renews visibility timeouts for long-running tasks."""
-        # Calculate renewal interval based on max visibility timeout
+        # Calculate renewal interval based on the effective visibility timeout: the
+        # deadline actually applied to the subscription is the requested value
+        # (max_runtime + 10) clipped to the provider maximum, so renewals must be
+        # scheduled against that, not the provider maximum alone.
         max_visibility = self._task_queue.get_max_visibility_timeout()
         if max_visibility is None:
             logger.info("No max visibility timeout found, skipping visibility renewal worker")
             return
+        effective_visibility = min(self._data.max_runtime + 10, max_visibility)
 
-        renewal_check_interval = max(max_visibility // 10, 10)
+        renewal_check_interval = max(effective_visibility // 10, 10)
 
-        when_to_renew = max_visibility // 2  # Renew half way through the visibility timeout
+        when_to_renew = effective_visibility // 2  # Renew half way through the visibility timeout
 
         logger.info(f"Starting visibility renewal worker with {renewal_check_interval}s interval")
 

--- a/tests/cloud_tasks/queue_manager/test_gcp.py
+++ b/tests/cloud_tasks/queue_manager/test_gcp.py
@@ -1060,6 +1060,98 @@ async def test_create_topic_subscription_already_exists(gcp_queue, mock_pubsub_c
 
 
 @pytest.mark.asyncio
+async def test_preexisting_subscription_ack_deadline_updated(mock_pubsub_client, gcp_config):
+    """A pre-existing subscription's ack deadline is updated to the requested (clipped) value.
+
+    This is the worker path: the dispatcher creates the subscription with the default
+    ack deadline, then the worker connects with visibility_timeout=max_runtime+10. Without
+    the update, messages expire and are redelivered while tasks are still being processed.
+    """
+    mock_publisher, mock_subscriber = mock_pubsub_client
+
+    # Topic and subscription already exist (created by the dispatcher)
+    mock_publisher.get_topic.side_effect = None
+    mock_publisher.get_topic.return_value = MagicMock(name="existing-topic")
+    mock_subscriber.get_subscription.side_effect = None
+    mock_subscriber.get_subscription.return_value = MagicMock(name="existing-subscription")
+
+    # Request a visibility timeout above the GCP maximum; it must be clipped
+    queue = GCPPubSubQueue(gcp_config, visibility_timeout=10010)
+    assert queue._subscription_exists is True
+
+    await queue.ensure_queue_ready()
+
+    # update_subscription is the real GCP API for this (modify_subscription does not exist
+    # on SubscriberClient; only a MagicMock would accept it)
+    mock_subscriber.update_subscription.assert_called_once_with(
+        request={
+            "subscription": {
+                "name": "projects/test-project/subscriptions/test-queue-subscription",
+                "ack_deadline_seconds": GCP_MAX_ACK_DEADLINE_SECONDS,
+            },
+            "update_mask": {"paths": ["ack_deadline_seconds"]},
+        }
+    )
+    assert not mock_subscriber.modify_subscription.called
+    assert not mock_subscriber.create_subscription.called
+
+    # The update is applied at most once, not on every ensure/ack/receive
+    await queue.ensure_queue_ready()
+    assert mock_subscriber.update_subscription.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preexisting_subscription_no_visibility_timeout_no_update(
+    mock_pubsub_client, gcp_config
+):
+    """Without a requested visibility timeout, a pre-existing subscription is left untouched."""
+    mock_publisher, mock_subscriber = mock_pubsub_client
+
+    mock_publisher.get_topic.side_effect = None
+    mock_publisher.get_topic.return_value = MagicMock(name="existing-topic")
+    mock_subscriber.get_subscription.side_effect = None
+    mock_subscriber.get_subscription.return_value = MagicMock(name="existing-subscription")
+
+    queue = GCPPubSubQueue(gcp_config)
+
+    await queue.ensure_queue_ready()
+
+    assert not mock_subscriber.update_subscription.called
+    assert not mock_subscriber.create_subscription.called
+
+
+@pytest.mark.asyncio
+async def test_create_subscription_already_exists_race_updates_deadline(
+    mock_pubsub_client, gcp_config
+):
+    """If creation races with another process, the ack deadline is still applied."""
+    mock_publisher, mock_subscriber = mock_pubsub_client
+
+    # Subscription does not exist at construction time...
+    queue = GCPPubSubQueue(gcp_config, visibility_timeout=300)
+    assert queue._subscription_exists is False
+
+    # ...but another process creates it before our create_subscription call lands
+    mock_subscriber.create_subscription.side_effect = gcp_exceptions.AlreadyExists(
+        "Subscription already exists"
+    )
+
+    await queue.ensure_queue_ready()
+
+    assert queue._subscription_exists is True
+    mock_subscriber.update_subscription.assert_called_once_with(
+        request={
+            "subscription": {
+                "name": "projects/test-project/subscriptions/test-queue-subscription",
+                "ack_deadline_seconds": 300,
+            },
+            "update_mask": {"paths": ["ack_deadline_seconds"]},
+        }
+    )
+    assert not mock_subscriber.modify_subscription.called
+
+
+@pytest.mark.asyncio
 async def test_send_message(gcp_queue, mock_pubsub_client):
     """Test sending a message to the queue."""
     mock_publisher, mock_subscriber = mock_pubsub_client


### PR DESCRIPTION
## Problem

A worker connecting to a subscription created by the dispatcher never applied its requested visibility timeout, so the subscription kept the default **60s ack deadline** while tasks ran for many minutes. Every task longer than 60s was redelivered and re-executed (duplicate work), and the original execution's completion ack used a stale ack_id and silently failed — completed tasks cycled through the queue indefinitely. Observed in production on `metadata-index-job` runs (rms-metadata project): tasks taking 615–633s were redelivered and restarted the moment worker slots freed.

Two defects combined to cause this:

1. `GCPPubSubQueue.__init__` pre-checks `get_subscription` and sets `_subscription_exists = True`, so `_create_subscription` returned early and never touched the deadline of a pre-existing subscription (the dispatcher creates it with the 60s default; there is no config knob for it).
2. The `AlreadyExists` fallback that was supposed to update the deadline called `SubscriberClient.modify_subscription`, **which does not exist** on the Pub/Sub client (the real API is `update_subscription` with a field mask). Only reachable in a create race, and the test suite's plain `MagicMock` subscriber happily accepted the nonexistent method, so it was never caught.

Additionally, the visibility renewal loop scheduled its first renewal at `provider_max // 2` (300s) — far too late for any deadline shorter than the provider maximum.

## Fix

- New `_update_ack_deadline()` applies `self._visibility_timeout` to a pre-existing subscription (at most once per queue instance) via `update_subscription` with an `ack_deadline_seconds` update mask. Called from both the early-return path and the `AlreadyExists` race branch; a freshly created subscription marks the deadline as already applied.
- The worker's renewal loop now schedules against the effective deadline `min(max_runtime + 10, provider_max)` instead of the provider maximum alone.

## Tests

- Pre-existing subscription + requested timeout → `update_subscription` called exactly once with the clipped (600s) value; never `modify_subscription`; idempotent across repeated `ensure_queue_ready()` calls.
- Pre-existing subscription without a requested timeout → left untouched.
- `AlreadyExists` create race → deadline still applied.

Full suite: 553 passed, 1 skipped. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhL2gSUum6zECag4iLrWh1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task visibility timeout handling for existing and newly created subscriptions.
  * Prevented redundant subscription updates and ensured timeout settings are applied reliably during creation races.
  * Adjusted visibility renewal timing to better reflect the configured task runtime while respecting provider limits.
  * Improved behavior when no provider renewal limit is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->